### PR TITLE
パッケージ利用側も annofabapi の型ヒントを利用したい

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,8 @@ setup(
         "Topic :: Utilities",
         "Operating System :: OS Independent",
     ],
-    packages=find_packages(exclude=["tests"])
+    packages=find_packages(exclude=["tests"]),
+    package_data={
+        "annofabapi": ["py.typed"]
+    }
 )


### PR DESCRIPTION
PEP561 に従い、py.typed ファイルをパッケージに含めることで、ライブラリ利用側でも型ヒントを利用できます。
https://blog.ymyzk.com/2018/09/creating-packages-using-pep-561/