### PR TITLE
logにauthorization headerを出力しないようにする

### DIFF
--- a/annofabapi/utils.py
+++ b/annofabapi/utils.py
@@ -3,6 +3,7 @@ Annofab APIのutils
 
 """
 
+import copy
 import datetime
 import logging
 from pathlib import Path
@@ -44,9 +45,14 @@ def log_error_response(arg_logger: logging.Logger, response: requests.Response):
     """
 
     if 400 <= response.status_code < 600:
+        headers = copy.deepcopy(response.request.headers)
+        if "Authorization" in headers:
+            # logにAuthorizationを出力しないようにマスクする
+            headers["Authorization"] = "***"
+
         arg_logger.debug(f"status_code = %s, response.text = %s", response.status_code, response.text)
         arg_logger.debug(f"request.url = %s %s", response.request.method, response.request.url)
-        arg_logger.debug("request.headers = %s", response.request.headers)
+        arg_logger.debug("request.headers = %s", headers)
         arg_logger.debug("request.body = %s", response.request.body)
 
 


### PR DESCRIPTION
authorization headerの替わりに`***`でマスクする。