### PR TITLE
‘SimpleAnnotationParser.parse‘:SimpleAnnotationDetailクラスのdataプロパティを変換する関数を指定できるようにする

### DIFF
--- a/annofabapi/dataclass/annotation.py
+++ b/annofabapi/dataclass/annotation.py
@@ -25,7 +25,7 @@ from annofabapi.models import (
 )
 
 AnnotationData = Union[str, Dict[str, Any]]
-FullAnnotationData = Dict[str, Any]
+FullAnnotationData = Any
 AdditionalDataValue = Dict[str, Any]
 
 
@@ -191,7 +191,7 @@ class FullAnnotationDetail(DataClassJsonMixin):
     data_holding_type: Optional[AnnotationDataHoldingType]
     """"""
 
-    data: Optional[FullAnnotationData]
+    data: FullAnnotationData
     """"""
 
     additional_data_list: Optional[List[FullAnnotationAdditionalData]]
@@ -223,7 +223,7 @@ class FullAnnotation(DataClassJsonMixin):
     input_data_name: Optional[str]
     """"""
 
-    details: Optional[List[FullAnnotationDetail]]
+    details: List[FullAnnotationDetail]
     """"""
 
     updated_datetime: Optional[str]

--- a/annofabapi/parser.py
+++ b/annofabapi/parser.py
@@ -3,12 +3,12 @@ import json
 import os
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional,Callable
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from annofabapi.dataclass.annotation import FullAnnotation, SimpleAnnotation
 from annofabapi.exceptions import AnnotationOuterFileNotFoundError
 
-CONVERT_ANNOTATION_DETAIL_DATA_FUNC=Callable[[Dict[str,Any]], Any]
+CONVERT_ANNOTATION_DETAIL_DATA_FUNC = Callable[[Dict[str, Any]], Any]
 
 
 def _trim_extension(file_path: str) -> str:
@@ -74,7 +74,9 @@ class SimpleAnnotationParser(abc.ABC):
 
         """
 
-    def parse(self, convert_deitail_data_func:Optional[CONVERT_ANNOTATION_DETAIL_DATA_FUNC]=None) -> SimpleAnnotation:
+    def parse(
+        self, convert_deitail_data_func: Optional[CONVERT_ANNOTATION_DETAIL_DATA_FUNC] = None
+    ) -> SimpleAnnotation:
         """JSONファイルをパースする
 
         Args:
@@ -84,12 +86,12 @@ class SimpleAnnotationParser(abc.ABC):
         Returns:
             SimpleAnnotationインスタンス
         """
-        
-        simple_annotation = SimpleAnnotation.from_dict(self.load_json())  # type: ignore        
-        for detail in simple_annotation.details:
-            detail.data = convert_deitail_data_func(detail.data) 
-        return simple_annotation
 
+        simple_annotation = SimpleAnnotation.from_dict(self.load_json())  # type: ignore
+        if convert_deitail_data_func is not None:
+            for detail in simple_annotation.details:
+                detail.data = convert_deitail_data_func(detail.data)
+        return simple_annotation
 
     @abc.abstractmethod
     def load_json(self) -> Any:
@@ -162,7 +164,7 @@ class FullAnnotationParser(abc.ABC):
         JSONファイルをloadします。
         """
 
-    def parse(self, convert_deitail_data_func:Optional[CONVERT_ANNOTATION_DETAIL_DATA_FUNC]=None) -> FullAnnotation:
+    def parse(self, convert_deitail_data_func: Optional[CONVERT_ANNOTATION_DETAIL_DATA_FUNC] = None) -> FullAnnotation:
         """JSONファイルをパースする
 
         Args:
@@ -172,12 +174,12 @@ class FullAnnotationParser(abc.ABC):
         Returns:
             FullAnnotationインスタンス
         """
-        
-        full_annotation = FullAnnotation.from_dict(self.load_json())  # type: ignore        
-        for detail in full_annotation.details:
-            detail.data = convert_deitail_data_func(detail.data) 
-        return full_annotation
 
+        full_annotation = FullAnnotation.from_dict(self.load_json())  # type: ignore
+        if convert_deitail_data_func is not None:
+            for detail in full_annotation.details:
+                detail.data = convert_deitail_data_func(detail.data)
+        return full_annotation
 
 
 class SimpleAnnotationZipParser(SimpleAnnotationParser):
@@ -201,7 +203,6 @@ class SimpleAnnotationZipParser(SimpleAnnotationParser):
     def __init__(self, zip_file: zipfile.ZipFile, json_file_path: str):
         self.__zip_file = zip_file
         super().__init__(json_file_path)
-
 
     def load_json(self) -> Any:
         with self.__zip_file.open(self.json_file_path) as entry:

--- a/generate/partial-header/dataclass/annotation.py
+++ b/generate/partial-header/dataclass/annotation.py
@@ -1,12 +1,12 @@
 from annofabapi.models import (
-    AnnotationDataHoldingType,
-    InternationalizationMessage,
     AdditionalDataDefinitionType,
+    AnnotationDataHoldingType,
     AnnotationType,
+    InternationalizationMessage,
     TaskPhase,
     TaskStatus,
 )
 
 AnnotationData = Union[str, Dict[str, Any]]
-FullAnnotationData = Dict[str, Any]
+FullAnnotationData = Any
 AdditionalDataValue = Dict[str, Any]


### PR DESCRIPTION
SimpleAnnotationDetailクラスのdataプロパティをdictからdataclassに変換できるようにするため、dataプロパティを変換する関数を渡せるようにしました。

以下のクラスの`parse`メソッドが変更対象です。
* SimpleAnnotationParser
* FullAnnotationParser



```
    def convert_deitail_data(self, dict_data):
        if dict_data["_type"] == "Points":
            dict_data["type"] = dict_data["_type"]
            return FullAnnotationDataPoints.from_dict(dict_data)
        else:
            return dict_data

    def test_parse_for_zip(self):
        zip_path = Path(test_dir / "simple-annotation.zip")
        with zipfile.ZipFile(zip_path) as zip_file:
            parser = SimpleAnnotationZipParser(zip_file, "sample_1/c86205d1-bdd4-4110-ae46-194e661d622b.json")

            simple_annotation2 = parser.parse(self.convert_deitail_data)
            assert type(simple_annotation2.details[0].data) == FullAnnotationDataPoints

```