### PR TITLE
リリースする際のpoetryバージョンを1.7にする

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: "3.10"
     - name: Install poetry
       run: |
-          python -m pip install "poetry<1.5" poetry-dynamic-versioning
+          python -m pip install "poetry<1.7" poetry-dynamic-versioning
     - name: Publish
       env:
         PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
poetry1.4のままでは`poetry build`時のMETADATAに、以下の情報が含まれないため。

```
Classifier: Programming Language :: Python :: 3.12
```
