### PR TITLE
`annofabapi.resources.build`関数の修正

### DIFF
--- a/annofabapi/exceptions.py
+++ b/annofabapi/exceptions.py
@@ -13,6 +13,12 @@ class AnnofabApiException(Exception):
     """
 
 
+class CredentialsNotFoundError(AnnofabApiException):
+    """
+    Annofabの認証情報が見つからないときのエラー
+    """
+
+
 class AnnotationOuterFileNotFoundError(AnnofabApiException):
     """
     アノテーション情報の外部ファイル（塗りつぶしの画像ファイルなど）が、存在しない場合のエラー

--- a/annofabapi/resource.py
+++ b/annofabapi/resource.py
@@ -64,17 +64,12 @@ def build(
         try:
             return build_from_env(endpoint_url)
         except AnnofabApiException:
-            pass
-
-        try:
-            return build_from_netrc(endpoint_url)
-        except AnnofabApiException:
-            pass
-
-        raise AnnofabApiException("環境変数または`.netrc`ファイルにAnnofab認証情報はありませんでした。")
-
+            try:
+                return build_from_netrc(endpoint_url)
+            except AnnofabApiException:
+                raise AnnofabApiException("環境変数または`.netrc`ファイルにAnnofab認証情報はありませんでした。")
     else:
-        raise ValueError()
+        raise ValueError("引数`login_user_id`か`login_password`のどちらか一方がNoneです。両方Noneでないか、両方Noneである必要があります。")
 
 
 def build_from_netrc(endpoint_url: str = DEFAULT_ENDPOINT_URL) -> Resource:

--- a/tests/test_local_resource.py
+++ b/tests/test_local_resource.py
@@ -21,8 +21,8 @@ class TestBuild:
         with pytest.raises(ValueError):
             annofabapi.AnnofabApi("test_user", "")
 
-    def test_build_from_env_raise_AnnofabApiException(self):
-        with pytest.raises(annofabapi.exceptions.AnnofabApiException):
+    def test_build_from_env_raise_CredentialsNotFoundError(self):
+        with pytest.raises(annofabapi.exceptions.CredentialsNotFoundError):
             os.environ.pop("ANNOFAB_USER_ID", None)
             os.environ.pop("ANNOFAB_PASSWORD", None)
             build_from_env()

--- a/tests/test_local_resource.py
+++ b/tests/test_local_resource.py
@@ -33,9 +33,17 @@ class TestBuild:
         assert isinstance(build_from_env(), annofabapi.Resource)
 
     def test_build(self):
+        assert isinstance(build(login_user_id="FOO", login_password="BAR"), annofabapi.Resource)
+
+        with pytest.raises(ValueError):
+            build(login_user_id="FOO", login_password=None)
+
+        with pytest.raises(ValueError):
+            build(login_user_id=None, login_password="BAR")
+
         os.environ["ANNOFAB_USER_ID"] = "FOO"
         os.environ["ANNOFAB_PASSWORD"] = "BAR"
-        assert isinstance(build(), annofabapi.Resource)
+        assert isinstance(build(login_user_id=None, login_password=None), annofabapi.Resource)
 
     def test_build_with_endpoint(self):
         user_id = "test_user"


### PR DESCRIPTION
`annofabapi.resources.build`関数を以下の通り変更しました。
* スローするExceptionを`AnnofabApiException`から`CredentilasNotFoundError`に変更
* Exceptionのメッセージを適切な内容に変更