### PR TITLE
`login` APIに失敗したときに、センシティブな情報がログに出力されてしまう問題を修正しました。

### DIFF
--- a/annofabapi/api.py
+++ b/annofabapi/api.py
@@ -2,10 +2,9 @@ import copy
 import json
 import logging
 import time
-from collections.abc import Collection
 from functools import wraps
 from json import JSONDecodeError
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Collection, Dict, Optional, Tuple
 
 import backoff
 import requests

--- a/annofabapi/api.py
+++ b/annofabapi/api.py
@@ -100,7 +100,6 @@ def _log_error_response(arg_logger: logging.Logger, response: requests.Response)
         # logにAuthorizationを出力しないようにマスクする
         headers_for_logger = _mask_senritive_value_for_dict(dict(response.request.headers), {"Authorization"})
 
-
         # request_bodyのpassword関係をマスクして、logに出力する
         request_body_for_logger: Optional[Any] = None
         if isinstance(response.request.body, bytes):
@@ -144,28 +143,13 @@ def _create_request_body_for_logger(data: Any) -> Any:  # noqa: ANN401
     Returns:
         ログ出力用のrequest_body
     """
-
-    def mask_key(d, key: str):  # noqa: ANN001, ANN202
-        if key in d:
-            d[key] = "***"
-
     if not isinstance(data, dict):
         return data
     elif isinstance(data, bytes):
         # bytes型のときは値を出力しても意味がないので、bytesであることが分かるようにする
         return "(bytes)"
 
-    MASKED_KEYS = {"password", "old_password", "new_password", "id_token", "refresh_token", "access_token"}
-    diff = MASKED_KEYS - set(data.keys())
-    if len(diff) == len(MASKED_KEYS):
-        # マスク対象のキーがない
-        return data
-
-    copied_data = copy.deepcopy(data)
-    for key in MASKED_KEYS:
-        mask_key(copied_data, key)
-
-    return copied_data
+    return _mask_senritive_value_for_dict(data, keys={"password", "old_password", "new_password", "id_token", "refresh_token", "access_token"})
 
 
 def _create_query_params_for_logger(params: Dict[str, Any]) -> Dict[str, Any]:
@@ -179,22 +163,7 @@ def _create_query_params_for_logger(params: Dict[str, Any]) -> Dict[str, Any]:
     Returns:
         ログ出力用のparams
     """
-
-    def mask_key(d, key: str):  # noqa: ANN001, ANN202
-        if key in d:
-            d[key] = "***"
-
-    MASKED_KEYS = {"X-Amz-Security-Token", "X-Amz-Credential"}
-    diff = MASKED_KEYS - set(params.keys())
-    if len(diff) == len(MASKED_KEYS):
-        # マスク対象のキーがない
-        return params
-
-    copied_params = copy.deepcopy(params)
-    for key in MASKED_KEYS:
-        mask_key(copied_params, key)
-
-    return copied_params
+    return _mask_senritive_value_for_dict(params, keys={"X-Amz-Security-Token", "X-Amz-Credential"})
 
 
 def _should_retry_with_status(status_code: int) -> bool:

--- a/poetry.lock
+++ b/poetry.lock
@@ -359,8 +359,11 @@ name = "docutils"
 version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
 optional = false
-python-versions = "*"
-files = []
+python-versions = ">=3.7"
+files = [
+    {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
+    {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
+]
 
 [[package]]
 name = "exceptiongroup"
@@ -1085,13 +1088,13 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.2.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-8.2.1-py3-none-any.whl", hash = "sha256:faccc5d332b8c3719f40283d0d44aa5cf101cec36f88cde9ed8f2bc0538612b1"},
+    {file = "pytest-8.2.1.tar.gz", hash = "sha256:5046e5b46d8e4cac199c373041f26be56fdb81eb4e67dc11d4e10811fc3408fd"},
 ]
 
 [package.dependencies]
@@ -1099,11 +1102,11 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+pluggy = ">=1.5,<2.0"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
@@ -1539,4 +1542,4 @@ segmentation = ["numpy", "numpy", "pillow"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f56133f4caa2050c0b28abcf02a5026733a06230048ae3e0432902bc1d789a2a"
+content-hash = "4caf6b3eb6a9083a8c774d91187bf5891521042b34b788d62b27ae2d45719219"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ segmentation = ["numpy", "pillow"]
 
 
 [tool.poetry.group.test.dependencies]
-pytest = "^7"
+pytest = "^8"
 pytest-xdist = "*"
 pytest-cov = "*"
 


### PR DESCRIPTION
APIに失敗したとき、パスワードがマスクされずにログに出力されるのを修正しました。

### 変更前

```
ERROR    : 2024-05-28 13:37:11,053 : annofabapi.api                 : HTTP error occurred :: {'response': {'status_code': 401, 'text': '{"errors":[{"error_code":"LOGIN_FAILED","message":"ユーザー名またはパスワードが違います","ext":{}}],"context":
...
 'request': {'http_method': 'POST', 'url': 'https://annofab.com/api/v1/login', 'body': b'{"user_id": "alice", "password": "alice_password"}...
```