### PR TITLE
MFAコードを標準入力から入力できるオプションを用意しました。

### DIFF
--- a/annofabapi/api.py
+++ b/annofabapi/api.py
@@ -148,7 +148,7 @@ def _create_request_body_for_logger(data: Any) -> Any:  # noqa: ANN401
         # bytes型のときは値を出力しても意味がないので、bytesであることが分かるようにする
         return "(bytes)"
 
-    return _mask_senritive_value_for_dict(data, keys={"password", "old_password", "new_password", "id_token", "refresh_token", "access_token"})
+    return _mask_senritive_value_for_dict(data, keys={"password", "old_password", "new_password", "id_token", "refresh_token", "access_token", "session"})
 
 
 def _create_query_params_for_logger(params: Dict[str, Any]) -> Dict[str, Any]:

--- a/annofabapi/exceptions.py
+++ b/annofabapi/exceptions.py
@@ -82,3 +82,9 @@ class MfaEnabledUserExecutionError(Exception):
     def __init__(self, user_id: str) -> None:
         message = f"User (User ID: {user_id}) cannot use annofab-api-python-client because MFA is enabled."
         super().__init__(message)
+
+
+class InvalidMfaCodeError(AnnofabApiException):
+    """
+    MFAコードが間違っている場合のエラー
+    """

--- a/annofabapi/exceptions.py
+++ b/annofabapi/exceptions.py
@@ -88,3 +88,6 @@ class InvalidMfaCodeError(AnnofabApiException):
     """
     MFAコードが間違っている場合のエラー
     """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/annofabapi/resource.py
+++ b/annofabapi/resource.py
@@ -73,17 +73,17 @@ def build(
 
     elif login_user_id is None and login_password is None:
         try:
-            return build_from_env(endpoint_url, input_mfa_code_via_stdin=input_mfa_code_via_stdin)
+            return build_from_env(endpoint_url=endpoint_url, input_mfa_code_via_stdin=input_mfa_code_via_stdin)
         except CredentialsNotFoundError:
             try:
-                return build_from_netrc(endpoint_url, input_mfa_code_via_stdin=input_mfa_code_via_stdin)
+                return build_from_netrc(endpoint_url=endpoint_url, input_mfa_code_via_stdin=input_mfa_code_via_stdin)
             except CredentialsNotFoundError as e:
                 raise CredentialsNotFoundError("環境変数または`.netrc`ファイルにAnnofab認証情報はありませんでした。") from e
     else:
         raise ValueError("引数`login_user_id`か`login_password`のどちらか一方がNoneです。両方Noneでないか、両方Noneである必要があります。")
 
 
-def build_from_netrc(endpoint_url: str = DEFAULT_ENDPOINT_URL, input_mfa_code_via_stdin: bool = False) -> Resource:
+def build_from_netrc(*, endpoint_url: str = DEFAULT_ENDPOINT_URL, input_mfa_code_via_stdin: bool = False) -> Resource:
     """
     ``.netrc`` ファイルから、annofabapi.Resourceインスタンスを生成する。
 
@@ -117,7 +117,7 @@ def build_from_netrc(endpoint_url: str = DEFAULT_ENDPOINT_URL, input_mfa_code_vi
     return Resource(login_user_id, login_password, endpoint_url=endpoint_url, input_mfa_code_via_stdin=input_mfa_code_via_stdin)
 
 
-def build_from_env(endpoint_url: str = DEFAULT_ENDPOINT_URL, input_mfa_code_via_stdin: bool = False) -> Resource:
+def build_from_env(*, endpoint_url: str = DEFAULT_ENDPOINT_URL, input_mfa_code_via_stdin: bool = False) -> Resource:
     """
     環境変数 ``ANNOFAB_USER_ID`` , ``ANNOFAB_PASSWORD`` から、annofabapi.Resourceインスタンスを生成する。
 

--- a/tests/test_local_resource.py
+++ b/tests/test_local_resource.py
@@ -49,7 +49,7 @@ class TestBuild:
     def test_build_with_endpoint(self):
         user_id = "test_user"
         password = "password"
-        resource = build(user_id, password, "https://localhost:8080")
+        resource = build(user_id, password, endpoint_url="https://localhost:8080")
         assert resource.api.url_prefix == "https://localhost:8080/api/v1"
         assert resource.api2.url_prefix == "https://localhost:8080/api/v2"
         assert resource.api.login_user_id == user_id


### PR DESCRIPTION
`input_mfa_code_via_stdin=True`を指定すると、標準入力からMFAコードを入力できるようにしました。

```
In [12]: from annofabapi import build
In [15]: s=build(input_mfa_code_via_stdin=True)
In [6]: api.login()
Enter Annofab MFA Code: 231860

```