### PR TITLE
アノテーション仕様のメッセージを取得するutil関数を追加

### DIFF
--- a/annofabapi/api.py
+++ b/annofabapi/api.py
@@ -492,7 +492,7 @@ class AnnofabApi(AbstractAnnofabApi):
         """
 
         # TODO 判定条件が不明
-        if url_path.startswith("/internal/"):  # noqa: SIM108
+        if url_path.startswith("/internal/"):
             url = f"{self.endpoint_url}/api{url_path}"
         else:
             url = f"{self.url_prefix}{url_path}"

--- a/annofabapi/api2.py
+++ b/annofabapi/api2.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 import requests
 from requests.cookies import RequestsCookieJar
 
-import annofabapi.utils
+import annofabapi
 from annofabapi.api import (
     DEFAULT_WAITING_TIME_SECONDS_WITH_429_STATUS_CODE,
     AnnofabApi,

--- a/annofabapi/util/annotation_specs.py
+++ b/annofabapi/util/annotation_specs.py
@@ -38,7 +38,7 @@ STR_LANG = Literal["en-US", "ja-JP", "vi-VN"]
 """
 
 
-def get_message_with_lang(internationalization_message: dict[str, Any], lang: Union[Lang, STR_LANG]) -> Optional[str]:
+def get_message_with_lang(internationalization_message: dict[str, Any], lang: Union[Lang, STR_LANG]) -> Optional[str]:  # noqa: UP007
     """
     `InternalizationMessage`クラスの値から、指定した ``lang`` に対応するメッセージを取得します。
 

--- a/annofabapi/utils.py
+++ b/annofabapi/utils.py
@@ -161,24 +161,3 @@ def can_put_annotation(task: Task, my_account_id: str) -> bool:
     # ログインユーザはプロジェクトオーナであること前提
     return len(task["histories_by_phase"]) == 0 or task["account_id"] == my_account_id
 
-
-def get_message_for_i18n(internationalization_message: Dict[str, Any], lang: str = "en-US") -> str:
-    """
-    アノテーション仕様で使われている`InternalizationMessage`クラスの値から、指定された言語のメッセージを取得する。
-
-    Args:
-        internationalization_message: 多言語化されたメッセージ
-        lang: 取得したいメッセージに対応する言語コード。`en-US`または`ja-JP`のみサポートしています。
-
-    Returns:
-        指定した言語に対応するメッセージ。
-
-    Raises:
-        ValueError: 引数langに対応するメッセージが見つからない場合
-    """
-    messages: List[Dict[str, str]] = internationalization_message["messages"]
-    result = more_itertools.first_true(messages, pred=lambda e: e["lang"] == lang)
-    if result is not None:
-        return result["message"]
-    else:
-        raise ValueError(f"lang='{lang}'であるメッセージは見つかりませんでした。")

--- a/annofabapi/utils.py
+++ b/annofabapi/utils.py
@@ -1,10 +1,9 @@
 import datetime
 import logging
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 import dateutil
 import dateutil.tz
-import more_itertools
 
 from annofabapi.models import Task, TaskHistory, TaskHistoryShort, TaskPhase
 
@@ -160,4 +159,3 @@ def can_put_annotation(task: Task, my_account_id: str) -> bool:
     """
     # ログインユーザはプロジェクトオーナであること前提
     return len(task["histories_by_phase"]) == 0 or task["account_id"] == my_account_id
-

--- a/annofabapi/utils/annotation_specs.py
+++ b/annofabapi/utils/annotation_specs.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Optional, Union
+
+import more_itertools
+
+from annofabapi.models import Lang
+
+
+def get_english_message(internationalization_message: dict[str, Any]) -> str:
+    """
+    `InternalizationMessage`クラスの値から、英語メッセージを取得します。
+    英語メッセージが見つからない場合は ``ValueError`` をスローします。
+
+    Notes:
+        英語メッセージは必ず存在するはずなので、英語メッセージが見つからない場合は ``ValueError`` をスローするようにしました。
+
+    Args:
+        internationalization_message: 多言語化されたメッセージ。キー ``messages`` が存在している必要があります。
+
+    Returns:
+        指定した言語に対応するメッセージ。
+
+    Raises:
+        ValueError: 英語メッセージが見つからない場合
+    """
+    messages: list[dict[str, str]] = internationalization_message["messages"]
+    result = more_itertools.first_true(messages, pred=lambda e: e["lang"] == Lang.EN_US.value)
+    if result is not None:
+        return result["message"]
+    else:
+        raise ValueError(f"'{internationalization_message}'に英語のメッセージは存在しません。")
+
+
+STR_LANG = Literal["en-US", "ja-JP", "vi-VN"]
+"""
+対応している ``lang`` の文字列
+"""
+
+
+def get_message_with_lang(internationalization_message: dict[str, Any], lang: Union[Lang, STR_LANG]) -> Optional[str]:
+    """
+    `InternalizationMessage`クラスの値から、指定した ``lang`` に対応するメッセージを取得します。
+
+    Args:
+        internationalization_message: 多言語化されたメッセージ。キー ``messages`` が存在している必要があります。
+        lang: 取得したいメッセージに対応する言語コード。
+
+    Returns:
+        指定した言語に対応するメッセージ。見つからない場合はNoneを返します。
+
+    """
+    messages: list[dict[str, str]] = internationalization_message["messages"]
+    if isinstance(lang, Lang):
+        str_lang = lang.value
+    else:
+        str_lang = str(lang)
+
+    result = more_itertools.first_true(messages, pred=lambda e: e["lang"] == str_lang)
+    if result is not None:
+        return result["message"]
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ ignore = [
     "ERA", # : 役立つこともあるが、コメントアウトしていないコードも警告されるので無視する
     "TD", # flake8-todos
     "FIX", # flake8-fixme
+    "SIM108", # if-else-block-instead-of-if-exp, 三項演算子が読みにくい場合もあるので無視する
 
     # 以下のルールはコードに合っていないので無効化した
     "RSE", # flake8-raise

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,7 @@ import requests
 from more_itertools import first_true
 
 import annofabapi
-import annofabapi.utils
+import annofabapi.util
 from annofabapi.dataclass.annotation import AnnotationV2Output, SimpleAnnotation, SingleAnnotationV2
 from annofabapi.dataclass.annotation_specs import AnnotationSpecsV3
 from annofabapi.dataclass.comment import Comment
@@ -125,7 +125,7 @@ class TestAnnotationSpecs:
         request_body = {
             "labels": annotation_spec["labels"],
             "inspection_phrases": annotation_spec["inspection_phrases"],
-            "comment": f"{annofabapi.utils.str_now()} に更新しました。",
+            "comment": f"{annofabapi.util.str_now()} に更新しました。",
             "last_updated_datetime": last_updated_datetime,
         }
         puted_annotation_spec, _ = api.put_annotation_specs(project_id, request_body=request_body)
@@ -171,7 +171,7 @@ class TestComment:
                     "status": "open",
                     "_type": "Root",
                 },
-                "datetime_for_sorting": annofabapi.utils.str_now(),
+                "datetime_for_sorting": annofabapi.util.str_now(),
                 "_type": "Put",
             }
         ]
@@ -500,7 +500,7 @@ class TestStatistics:
                 "marker_id": test_marker_id,
                 "title": "add in test code",
                 "graph_type": GraphType.TASK_PROGRESS.value,
-                "marked_at": annofabapi.utils.str_now(),
+                "marked_at": annofabapi.util.str_now(),
             }
         ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -125,7 +125,7 @@ class TestAnnotationSpecs:
         request_body = {
             "labels": annotation_spec["labels"],
             "inspection_phrases": annotation_spec["inspection_phrases"],
-            "comment": f"{annofabapi.util.str_now()} に更新しました。",
+            "comment": f"{annofabapi.utils.str_now()} に更新しました。",
             "last_updated_datetime": last_updated_datetime,
         }
         puted_annotation_spec, _ = api.put_annotation_specs(project_id, request_body=request_body)
@@ -171,7 +171,7 @@ class TestComment:
                     "status": "open",
                     "_type": "Root",
                 },
-                "datetime_for_sorting": annofabapi.util.str_now(),
+                "datetime_for_sorting": annofabapi.utils.str_now(),
                 "_type": "Put",
             }
         ]
@@ -500,7 +500,7 @@ class TestStatistics:
                 "marker_id": test_marker_id,
                 "title": "add in test code",
                 "graph_type": GraphType.TASK_PROGRESS.value,
-                "marked_at": annofabapi.util.str_now(),
+                "marked_at": annofabapi.utils.str_now(),
             }
         ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import configparser
 import datetime
-import os
 import uuid
 from typing import Any
 
@@ -31,8 +30,6 @@ from annofabapi.models import GraphType, ProjectJobType
 from annofabapi.wrapper import TaskFrameKey
 from tests.utils_for_test import WrapperForTest, create_csv_for_task
 
-# プロジェクトトップに移動する
-os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")
 inifile = configparser.ConfigParser()
 inifile.read("./pytest.ini", "UTF-8")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,6 @@ import requests
 from more_itertools import first_true
 
 import annofabapi
-import annofabapi.util
 from annofabapi.dataclass.annotation import AnnotationV2Output, SimpleAnnotation, SingleAnnotationV2
 from annofabapi.dataclass.annotation_specs import AnnotationSpecsV3
 from annofabapi.dataclass.comment import Comment

--- a/tests/test_api2.py
+++ b/tests/test_api2.py
@@ -4,13 +4,10 @@ AnnofabApi2のテストメソッド
 """
 
 import configparser
-import os
 
 import annofabapi
 from tests.utils_for_test import WrapperForTest
 
-# プロジェクトトップに移動する
-os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")
 inifile = configparser.ConfigParser()
 inifile.read("./pytest.ini", "UTF-8")
 project_id = inifile["annofab"]["project_id"]

--- a/tests/test_api2.py
+++ b/tests/test_api2.py
@@ -7,7 +7,6 @@ import configparser
 import os
 
 import annofabapi
-import annofabapi.utils
 from tests.utils_for_test import WrapperForTest
 
 # プロジェクトトップに移動する

--- a/tests/test_local_parser.py
+++ b/tests/test_local_parser.py
@@ -1,5 +1,4 @@
 import configparser
-import os
 import zipfile
 from pathlib import Path
 
@@ -18,8 +17,6 @@ from annofabapi.parser import (
     SimpleAnnotationZipParserByTask,
 )
 
-# プロジェクトトップに移動する
-os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")
 inifile = configparser.ConfigParser()
 inifile.read("./pytest.ini", "UTF-8")
 

--- a/tests/test_local_parser.py
+++ b/tests/test_local_parser.py
@@ -7,7 +7,6 @@ import pytest
 
 import annofabapi
 import annofabapi.parser
-import annofabapi.utils
 from annofabapi.dataclass.annotation import FullAnnotation, FullAnnotationDataPoints, SimpleAnnotation
 from annofabapi.exceptions import AnnotationOuterFileNotFoundError
 from annofabapi.parser import (

--- a/tests/test_local_resource.py
+++ b/tests/test_local_resource.py
@@ -9,9 +9,6 @@ import pytest
 import annofabapi.exceptions
 from annofabapi.resource import build, build_from_env
 
-# プロジェクトトップに移動する
-os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")
-
 
 class TestBuild:
     # def test_build_from_netrc(self):

--- a/tests/test_local_utils.py
+++ b/tests/test_local_utils.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from annofabapi.models import TaskPhase
 from annofabapi.utils import (
-    get_message_for_i18n,
     get_number_of_rejections,
     get_task_history_index_skipped_acceptance,
     get_task_history_index_skipped_inspection,
@@ -617,20 +614,3 @@ class TestTaskHistoryUtils2:
         actual = get_task_history_index_skipped_inspection(task_history_list)
         expected: list[int] = []
         assert all([a == b for a, b in zip(actual, expected)])  # noqa: C419
-
-
-def test_get_message_for_i18n():
-    i18n_message = {
-        "messages": [{"lang": "ja-JP", "message": "自動車"}, {"lang": "en-US", "message": "car"}],
-        "default_lang": "ja-JP",
-    }
-    assert get_message_for_i18n(i18n_message) == "car"
-    assert get_message_for_i18n(i18n_message, lang="ja-JP") == "自動車"
-
-    i18n_message2 = {
-        "messages": [{"lang": "ja-JP", "message": "自動車"}],
-        "default_lang": "ja-JP",
-    }
-
-    with pytest.raises(ValueError):
-        get_message_for_i18n(i18n_message2, lang="en-US")

--- a/tests/test_local_wrapper.py
+++ b/tests/test_local_wrapper.py
@@ -1,10 +1,6 @@
-import os
 from pathlib import Path
 
 from annofabapi.wrapper import Wrapper
-
-# プロジェクトトップに移動する
-os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")
 
 data_dir = Path("./tests/data")
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -6,7 +6,6 @@ import configparser
 import os
 
 import annofabapi
-import annofabapi.utils
 
 # プロジェクトトップに移動する
 os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -3,12 +3,9 @@ Annofabプロジェクトやタスクに大きく依存したテストコード�
 """
 
 import configparser
-import os
 
 import annofabapi
 
-# プロジェクトトップに移動する
-os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")
 inifile = configparser.ConfigParser()
 inifile.read("./pytest.ini", "UTF-8")
 

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import uuid
 from pathlib import Path
@@ -7,9 +6,6 @@ import numpy
 from PIL import Image
 
 from annofabapi.segmentation import read_binary_image, write_binary_image
-
-# プロジェクトトップに移動する
-os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")
 
 data_dir = Path("./tests/data/segmentation")
 out_dir = Path("./tests/out/segmentation")

--- a/tests/util/test_local_annotation_specs.py
+++ b/tests/util/test_local_annotation_specs.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from annofabapi.utils.annotation_specs import Lang, get_english_message, get_message_with_lang
+from annofabapi.util.annotation_specs import Lang, get_english_message, get_message_with_lang
 
 # プロジェクトトップに移動する
 os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")

--- a/tests/util/test_local_annotation_specs.py
+++ b/tests/util/test_local_annotation_specs.py
@@ -1,13 +1,10 @@
 import configparser
-import os
 from pathlib import Path
 
 import pytest
 
 from annofabapi.util.annotation_specs import Lang, get_english_message, get_message_with_lang
 
-# プロジェクトトップに移動する
-os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")
 inifile = configparser.ConfigParser()
 inifile.read("./pytest.ini", "UTF-8")
 

--- a/tests/utils/test_local_annotation_specs.py
+++ b/tests/utils/test_local_annotation_specs.py
@@ -1,0 +1,42 @@
+import configparser
+import os
+from pathlib import Path
+
+import pytest
+
+from annofabapi.utils.annotation_specs import Lang, get_english_message, get_message_with_lang
+
+# プロジェクトトップに移動する
+os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/../")
+inifile = configparser.ConfigParser()
+inifile.read("./pytest.ini", "UTF-8")
+
+test_dir = Path("./tests/data")
+
+
+class Test__get_english_message:
+    def test__get_english_message(self):
+        i18n_message = {
+            "messages": [{"lang": "ja-JP", "message": "自動車"}, {"lang": "en-US", "message": "car"}],
+            "default_lang": "ja-JP",
+        }
+        assert get_english_message(i18n_message) == "car"
+
+    def test__get_english_message__英語メッセージが存在しない場合はValueErrorをスローする(self):
+        i18n_message = {
+            "messages": [{"lang": "ja-JP", "message": "自動車"}],
+            "default_lang": "ja-JP",
+        }
+        with pytest.raises(ValueError):
+            get_english_message(i18n_message)
+
+
+class Test__get_message_with_lang:
+    def test__get_message_with_lang(self):
+        i18n_message = {
+            "messages": [{"lang": "ja-JP", "message": "自動車"}, {"lang": "en-US", "message": "car"}],
+            "default_lang": "ja-JP",
+        }
+        assert get_message_with_lang(i18n_message, Lang.JA_JP) == "自動車"
+        assert get_message_with_lang(i18n_message, "en-US") == "car"
+        assert get_message_with_lang(i18n_message, Lang.VI_VN) is None


### PR DESCRIPTION

### 廃止
* `annofabapi.utils.get_message_for_i18n` : ベトナム語を取得しようとしたときに`ValueError`が発生すると使いにくかったので、以下の新しい関数を追加しました。今後は`annofabapi.util.annotation_specs.get_english_message`または`annofabapi.util.annotation_specs.get_message_with_lang`を利用してください。


### 追加
* `annofabapi.util.annotation_specs.get_english_message`
* `annofabapi.util.annotation_specs.get_message_with_lang`

※ すでに`utils.py`があったので、`util`という単数形のパッケージを作成しました。
