### PR TITLE
属性の制約に関するモジュール`attribute_restrictions`を追加しました。

### DIFF
--- a/annofabapi/util/annotation_specs.py
+++ b/annofabapi/util/annotation_specs.py
@@ -119,6 +119,12 @@ def get_label(labels: list[dict[str, Any]], *, label_id: Optional[str] = None, l
 
 
 class AnnotationSpecsAccessor:
+    """
+    アノテーション仕様の情報にアクセスするためのクラス。
+    
+    Args:
+        annotation_specs: アノテーション仕様(v3)の情報
+    """
     def __init__(self, annotation_specs: dict[str, Any]) -> None:
         self.labels = annotation_specs["labels"]
         self.additionals = annotation_specs["additionals"]

--- a/annofabapi/util/annotation_specs.py
+++ b/annofabapi/util/annotation_specs.py
@@ -121,10 +121,11 @@ def get_label(labels: list[dict[str, Any]], *, label_id: Optional[str] = None, l
 class AnnotationSpecsAccessor:
     """
     アノテーション仕様の情報にアクセスするためのクラス。
-    
+
     Args:
         annotation_specs: アノテーション仕様(v3)の情報
     """
+
     def __init__(self, annotation_specs: dict[str, Any]) -> None:
         self.labels = annotation_specs["labels"]
         self.additionals = annotation_specs["additionals"]

--- a/annofabapi/util/annotation_specs.py
+++ b/annofabapi/util/annotation_specs.py
@@ -8,7 +8,7 @@ from annofabapi.models import Lang
 
 def get_english_message(internationalization_message: dict[str, Any]) -> str:
     """
-    `InternalizationMessage`クラスの値から、英語メッセージを取得します。
+    `InternationalizationMessage`クラスの値から、英語メッセージを取得します。
     英語メッセージが見つからない場合は ``ValueError`` をスローします。
 
     Notes:
@@ -39,7 +39,7 @@ STR_LANG = Literal["en-US", "ja-JP", "vi-VN"]
 
 def get_message_with_lang(internationalization_message: dict[str, Any], lang: Union[Lang, STR_LANG]) -> Optional[str]:
     """
-    `InternalizationMessage`クラスの値から、指定した ``lang`` に対応するメッセージを取得します。
+    `InternationalizationMessage`クラスの値から、指定した ``lang`` に対応するメッセージを取得します。
 
     Args:
         internationalization_message: 多言語化されたメッセージ。キー ``messages`` が存在している必要があります。

--- a/annofabapi/util/annotation_specs.py
+++ b/annofabapi/util/annotation_specs.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 from typing import Any, Literal, Optional, Union
 
 import more_itertools
+from more_itertools import first_true
 
 from annofabapi.models import Lang
 
@@ -38,7 +37,7 @@ STR_LANG = Literal["en-US", "ja-JP", "vi-VN"]
 """
 
 
-def get_message_with_lang(internationalization_message: dict[str, Any], lang: Union[Lang, STR_LANG]) -> Optional[str]:  # noqa: UP007
+def get_message_with_lang(internationalization_message: dict[str, Any], lang: Union[Lang, STR_LANG]) -> Optional[str]:
     """
     `InternalizationMessage`クラスの値から、指定した ``lang`` に対応するメッセージを取得します。
 
@@ -60,3 +59,86 @@ def get_message_with_lang(internationalization_message: dict[str, Any], lang: Un
     if result is not None:
         return result["message"]
     return None
+
+
+def get_choice(choices: list[dict[str, Any]], *, choice_id: Optional[str] = None, choice_name: Optional[str] = None) -> dict[str, Any]:
+    """
+    選択肢情報を取得します。
+
+    Args:
+        choice_id: 選択肢ID
+        choice_name: 選択肢名(英語)
+    """
+    if choice_id is not None:
+        result = first_true(choices, pred=lambda e: e["choice_id"] == choice_id)
+    elif choice_name is not None:
+        result = first_true(choices, pred=lambda e: get_english_message(e["name"]) == choice_name)
+    else:
+        raise ValueError("choice_idまたはchoice_nameのいずれかを指定してください。")
+    if result is None:
+        raise ValueError(f"選択肢情報が見つかりませんでした。 :: choice_id='{choice_id}', choice_name='{choice_name}'")
+    return result
+
+
+def get_attribute(additionals: list[dict[str, Any]], *, attribute_id: Optional[str] = None, attribute_name: Optional[str] = None) -> dict[str, Any]:
+    """
+    属性情報を取得します。
+
+    Args:
+        attribute_id: 属性ID
+        attribute_name: 属性名(英語)
+    """
+    if attribute_id is not None:
+        result = first_true(additionals, pred=lambda e: e["additional_data_definition_id"] == attribute_id)
+    elif attribute_name is not None:
+        result = first_true(additionals, pred=lambda e: get_english_message(e["name"]) == attribute_name)
+    else:
+        raise ValueError("attribute_idまたはattribute_nameのいずれかを指定してください。")
+    if result is None:
+        raise ValueError(f"属性情報が見つかりませんでした。 :: attribute_id='{attribute_id}', attribute_name='{attribute_name}'")
+    return result
+
+
+def get_label(labels: list[dict[str, Any]], *, label_id: Optional[str] = None, label_name: Optional[str] = None) -> dict[str, Any]:
+    """
+    ラベル情報を取得します。
+
+    Args:
+        label_id: ラベルID
+        label_name: ラベル名(英語)
+    """
+    if label_id is not None:
+        result = first_true(labels, pred=lambda e: e["label_id"] == label_id)
+    elif label_name is not None:
+        result = first_true(labels, pred=lambda e: get_english_message(e["label_name"]) == label_name)
+    else:
+        raise ValueError("label_idまたはlabel_nameのいずれかを指定してください。")
+    if result is None:
+        raise ValueError(f"ラベル情報が見つかりませんでした。 :: label_id='{label_id}', label_name='{label_name}'")
+    return result
+
+
+class AnnotationSpecsAccessor:
+    def __init__(self, annotation_specs: dict[str, Any]) -> None:
+        self.labels = annotation_specs["labels"]
+        self.additionals = annotation_specs["additionals"]
+
+    def get_attribute(self, *, attribute_id: Optional[str] = None, attribute_name: Optional[str] = None) -> dict[str, Any]:
+        """
+        属性情報を取得します。
+
+        Args:
+            attribute_id: 属性ID
+            attribute_name: 属性名(英語)
+        """
+        return get_attribute(self.additionals, attribute_id=attribute_id, attribute_name=attribute_name)
+
+    def get_label(self, *, label_id: Optional[str] = None, label_name: Optional[str] = None) -> dict[str, Any]:
+        """
+        ラベル情報を取得します。
+
+        Args:
+            label_id: ラベルID
+            label_name: ラベル名(英語)
+        """
+        self.get_label(self.labels, label_id=label_id, label_name=label_name)

--- a/annofabapi/util/annotation_specs.py
+++ b/annofabapi/util/annotation_specs.py
@@ -141,4 +141,4 @@ class AnnotationSpecsAccessor:
             label_id: ラベルID
             label_name: ラベル名(英語)
         """
-        self.get_label(self.labels, label_id=label_id, label_name=label_name)
+        return get_label(self.labels, label_id=label_id, label_name=label_name)

--- a/annofabapi/util/attribute_restrictions.py
+++ b/annofabapi/util/attribute_restrictions.py
@@ -111,7 +111,7 @@ class Attribute(ABC):
         self.accessor = accessor
         self.attribute = self.accessor.get_attribute(attribute_id=attribute_id, attribute_name=attribute_name)
         self.attribute_id = self.attribute["additional_data_definition_id"]
-        if self.is_valid_attribute_type() is False:
+        if self._is_valid_attribute_type() is False:
             raise ValueError(f"属性の種類が'{self.attribute['type']}'である属性は、クラス'{self.__class__.__name__}'では扱えません。")
 
     def disabled(self) -> Condition:
@@ -119,7 +119,7 @@ class Attribute(ABC):
         return CanInput(self.attribute_id, enable=False)
 
     @abstractmethod
-    def is_valid_attribute_type(self) -> bool:
+    def _is_valid_attribute_type(self) -> bool:
         pass
 
 
@@ -134,14 +134,14 @@ class Checkbox(Attribute):
         """チェックされていないという条件"""
         return NotEquals(self.attribute_id, "true")
 
-    def is_valid_attribute_type(self) -> bool:
+    def _is_valid_attribute_type(self) -> bool:
         return self.attribute["type"] == "flag"
 
 
 class StringTextBox(Attribute, EmptyCheckMixin):
     """文字列用のテキストボックス（自由記述）の属性"""
 
-    def is_valid_attribute_type(self) -> bool:
+    def _is_valid_attribute_type(self) -> bool:
         return self.attribute["type"] in {"text", "comment"}
 
     def equals(self, value: str) -> Condition:
@@ -158,15 +158,11 @@ class StringTextBox(Attribute, EmptyCheckMixin):
         """引数`value`に渡された正規表現に一致しないという条件"""
         return NotMatches(self.attribute_id, value)
 
-    def required(self) -> Condition:
-        """必須入力という条件"""
-        return NotEquals(self.attribute_id, "")
-
 
 class IntegerTextBox(Attribute, EmptyCheckMixin):
     """整数用のテキストボックスの属性"""
 
-    def is_valid_attribute_type(self) -> bool:
+    def _is_valid_attribute_type(self) -> bool:
         return self.attribute["type"] == "integer"
 
     def equals(self, value: int) -> Condition:
@@ -177,16 +173,11 @@ class IntegerTextBox(Attribute, EmptyCheckMixin):
         """引数`value`に渡された整数に一致しないという条件"""
         return NotEquals(self.attribute_id, str(value))
 
-    def required(self) -> Condition:
-        """必須入力という条件"""
-        # TODO
-        return NotEquals(self.attribute_id, "")
-
 
 class AnnotationLink(Attribute, EmptyCheckMixin):
     """アノテーションリンク属性"""
 
-    def is_valid_attribute_type(self) -> bool:
+    def _is_valid_attribute_type(self) -> bool:
         return self.attribute["type"] == "link"
 
     def has_label(self, label_ids: Optional[Collection[str]] = None, label_names: Optional[Collection[str]] = None) -> Condition:
@@ -203,7 +194,7 @@ class AnnotationLink(Attribute, EmptyCheckMixin):
 class TrackingId(Attribute, EmptyCheckMixin):
     """トラッキングID属性"""
 
-    def is_valid_attribute_type(self) -> bool:
+    def _is_valid_attribute_type(self) -> bool:
         return self.attribute["type"] == "tracking"
 
     def equals(self, value: str) -> Condition:
@@ -216,7 +207,7 @@ class TrackingId(Attribute, EmptyCheckMixin):
 class Selection(Attribute, EmptyCheckMixin):
     """排他選択の属性（ドロップダウンまたラジオボタン）"""
 
-    def is_valid_attribute_type(self) -> bool:
+    def _is_valid_attribute_type(self) -> bool:
         return self.attribute["type"] in {"choice", "select"}
 
     def is_selected(self, choice_id: str, choice_name: str) -> Condition:

--- a/annofabapi/util/attribute_restrictions.py
+++ b/annofabapi/util/attribute_restrictions.py
@@ -5,82 +5,69 @@ from abc import ABC, abstractmethod
 
 
 class Condition(ABC):
-    def __init__(self, attr_id):
-        self._attr_id = attr_id
+    def __init__(self, attribute_id):
+        self._attr_id = attribute_id
 
     @property
     def attr_id(self) -> str:
         return self._attr_id
 
     def generate(self) -> dict[str, Any]:
-        return {
-            "additional_data_definition_id": self.attr_id,
-            "condition": self.generate_condition()
-        }
+        return {"additional_data_definition_id": self.attr_id, "condition": self.generate_condition()}
 
     @abstractmethod
     def generate_condition(self) -> dict[str, Any]:
         pass
 
-    def imply(self, condition: Condition) -> Condition2:
-        # implyを連続で使えない
-        return Imply(self, condition)
+    # def imply(self, condition: Condition) -> Condition2:
+    #     # implyを連続で使えない
+    #     return Imply(self, condition)
 
 
 class CanInput(Condition):
-    def __init__(self, attr_id: str, enable = False):
-        super().__init__(attr_id)
+    def __init__(self, attribute_id: str, enable: bool):
+        super().__init__(attribute_id)
         self.enable = enable
 
     def generate_condition(self) -> dict[str, Any]:
-        return {
-            "_type": "CanInput",
-            "enable": self.enable
-        }
+        return {"_type": "CanInput", "enable": self.enable}
+
 
 class Equals(Condition):
-    def __init__(self, attr_id: str, value: str):
-        super().__init__(attr_id)
+    def __init__(self, attribute_id: str, value: str):
+        super().__init__(attribute_id)
         self.value = value
 
     def generate_condition(self) -> dict[str, Any]:
-        return {
-            "_type": "Equals",
-            "value": self.value
-        }
+        return {"_type": "Equals", "value": self.value}
+
 
 class NotEquals(Condition):
-    def __init__(self, attr_id: str, value: str):
-        super().__init__(attr_id)
+    def __init__(self, attribute_id: str, value: str):
+        super().__init__(attribute_id)
         self.value = value
 
     def generate_condition(self) -> dict[str, Any]:
-        return {
-            "_type": "NotEquals",
-            "value": self.value
-        }
+        return {"_type": "NotEquals", "value": self.value}
+
 
 class Matches(Condition):
-    def __init__(self, attr_id: str, re: str):
-        super().__init__(attr_id)
-        self.re = re
+    def __init__(self, attribute_id: str, value: str):
+        super().__init__(attribute_id)
+        self.value = value
 
     def generate_condition(self) -> dict[str, Any]:
-        return {
-            "_type": "Matches",
-            "value": self.re
-        }
+        return {"_type": "Matches", "value": self.value}
+
 
 class NotMatches(Condition):
-    def __init__(self, attr_id: str, re: str):
-        super().__init__(attr_id)
-        self.re = re
+    def __init__(self, attribute_id: str, value: str):
+        super().__init__(attribute_id)
+        self.value = value
 
     def generate_condition(self) -> dict[str, Any]:
-        return {
-            "_type": "NotMatches",
-            "value": self.re
-        }
+        return {"_type": "NotMatches", "value": self.value}
+
 
 class HasLabel(Condition):
     def __init__(self, attr_id: str, label_ids: list[str]):
@@ -88,10 +75,8 @@ class HasLabel(Condition):
         self.label_ids = label_ids
 
     def generate_condition(self) -> dict[str, Any]:
-        return {
-            "_type": "HasLabel",
-            "value": self.label_ids
-        }
+        return {"_type": "HasLabel", "value": self.label_ids}
+
 
 class Imply(Condition):
     def __init__(self, pre_condition: Condition, post_condition: Condition):
@@ -100,56 +85,70 @@ class Imply(Condition):
         self.post_condition = post_condition
 
     def generate(self) -> dict[str, Any]:
-        return {
-            "additional_data_definition_id": self.attr_id,
-            "condition": self.generate_condition()
-        }
+        return {"additional_data_definition_id": self.attr_id, "condition": self.generate_condition()}
 
     def generate_condition(self) -> dict[str, Any]:
-        return {
-            "_type": "Imply",
-            "premise": self.pre_condition.generate(),
-            "condition": self.post_condition.generate_condition()
-        }
-
-
-
+        return {"_type": "Imply", "premise": self.pre_condition.generate(), "condition": self.post_condition.generate_condition()}
 
 
 class Attribute(ABC):
-    def __init__(self, attribute_id: str):
-        self.attr_id = attribute_id
-        
-        
-class LinkAttribute:
-    """アノテーションリンク属性"""
-    pass
+    def __init__(self, attribute_id: str) -> None:
+        self.attribute_id = attribute_id
+
+    def disabled(self) -> Condition:
+        """属性値を入力できないようにします。"""
+        return CanInput(self.attribute_id, enable=False)
 
 
 class Checkbox(Attribute):
     """チェックボックスの属性"""
+
     def checked(self) -> Condition:
-        return Equals(self.attr_id, value)
+        """チェックされているという条件"""
+        return Equals(self.attribute_id, "true")
 
     def unchecked(self) -> Condition:
-        return Equals(self.attr_id, value)
+        """チェックされていないという条件"""
+        return NotEquals(self.attribute_id, "true")
 
 
-class StringTextBoxAttribute:
+class StringTextBox(Attribute):
     """文字列用のテキストボックス（自由記述）の属性"""
+
+    def equals(self, value: str) -> Condition:
+        return Equals(self.attribute_id, value)
+
+    def not_equals(self, value: str) -> Condition:
+        return NotEquals(self.attribute_id, value)
+
+    def matches(self, value: str) -> Condition:
+        """引数`value`に渡された正規表現に一致するという条件"""
+        return Matches(self.attribute_id, value)
+
+    def not_matches(self, value: str) -> Condition:
+        """引数`value`に渡された正規表現に一致しないという条件"""
+        return NotMatches(self.attribute_id, value)
+
+
+class LinkAttribute:
+    """アノテーションリンク属性"""
+
     pass
+
 
 class IntegerTextBoxAttribute:
     """整数用のテキストボックスの属性"""
+
     pass
 
 
 class SelectionAttribute:
     """排他選択の属性（ドロップダウンまたラジオボタン）"""
+
     pass
 
 
 class TrackingIdAttribute:
     """トラッキングID属性"""
-    pass
 
+    pass

--- a/annofabapi/util/attribute_restrictions.py
+++ b/annofabapi/util/attribute_restrictions.py
@@ -4,39 +4,47 @@
 以下のサンプルコードのように属性名で制約情報を出力できます。
 
 Examples:
-    # 「'occluded'チェックボックスがONならば、'note'テキストボックスは空ではない」という制約
-    >>> premise_restriction = Checkbox(accessor, attribute_name="occluded").checked()
-    >>> conclusion_restriction = StringTextBox(accessor, attribute_name="note").is_not_empty()
-    >>> restriction = premise_restriction.imply(conclusion_restriction)
-    >>> restriction.to_dict()
-    {
-        "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
-        "condition": {
-            "_type": "Imply",
-            "premise": {
-                "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
-                "condition": {"_type": "Equals", "value": "true"},
-            },
-            "condition": {"_type": "NotEquals", "value": ""},
-        },
-    }
+    .. code-block:: python
 
-    # 「'occluded'チェックボックスがONならば、'car_kind'セレクトボックス(ラジオボタン)は選択肢'general_car'を選択しない」という制約
-    >>> premise_restriction = Checkbox(accessor, attribute_name="occluded").checked()
-    >>> conclusion_restriction = Selection(accessor, attribute_name="car_kind").not_has_choice(choice_name="general_car")
-    >>> restriction = premise_restriction.imply(conclusion_restriction)
-    >>> restriction.to_dict()
-    {
-        "additional_data_definition_id": "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
-        "condition": {
-            "_type": "Imply",
-            "premise": {
-                "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
-                "condition": {"_type": "Equals", "value": "true"},
+        >>> from annofabapi.util.annotation_specs import AnnotationSpecsAccessor
+        >>> from annofabapi.util.attribute_restrictions import Checkbox, Selection, StringTextBox
+        >>> service = annofabapi.build()
+        >>> annotation_specs, _ = service.api.get_annotation_specs("prj1", query_params={"v": "3"})
+        >>> accessor = AnnotationSpecsAccessor(annotation_specs)
+
+        # 「'occluded'チェックボックスがONならば、'note'テキストボックスは空ではない」という制約
+        >>> premise_restriction = Checkbox(accessor, attribute_name="occluded").checked()
+        >>> conclusion_restriction = StringTextBox(accessor, attribute_name="note").is_not_empty()
+        >>> restriction = premise_restriction.imply(conclusion_restriction)
+        >>> restriction.to_dict()
+        {
+            "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
+            "condition": {
+                "_type": "Imply",
+                "premise": {
+                    "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
+                    "condition": {"_type": "Equals", "value": "true"},
+                },
+                "condition": {"_type": "NotEquals", "value": ""},
             },
-            "condition": {"_type": "Equals", "value": "7512ee39-8073-4e24-9b8c-93d99b76b7d2"},
-        },
-    }
+        }
+
+        # 「'occluded'チェックボックスがONならば、'car_kind'セレクトボックス(またはラジオボタン)は選択肢'general_car'を選択しない」という制約
+        >>> premise_restriction = Checkbox(accessor, attribute_name="occluded").checked()
+        >>> conclusion_restriction = Selection(accessor, attribute_name="car_kind").not_has_choice(choice_name="general_car")
+        >>> restriction = premise_restriction.imply(conclusion_restriction)
+        >>> restriction.to_dict()
+        {
+            "additional_data_definition_id": "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
+            "condition": {
+                "_type": "Imply",
+                "premise": {
+                    "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
+                    "condition": {"_type": "Equals", "value": "true"},
+                },
+                "condition": {"_type": "Equals", "value": "7512ee39-8073-4e24-9b8c-93d99b76b7d2"},
+            },
+        }
 """
 
 from abc import ABC, abstractmethod

--- a/annofabapi/util/attribute_restrictions.py
+++ b/annofabapi/util/attribute_restrictions.py
@@ -97,13 +97,15 @@ class HasLabel(Condition):
 class EmptyCheckMixin:
     """属性が空かどうかを判定するメソッドを提供するMix-inクラス"""
 
+    attribute_id: str
+
     def is_empty(self) -> Condition:
-        """属性が空であるという条件"""
-        return Equals(self.attribute_id, "")
+        """属性値が空であるという条件"""
+        return Equals(self.attribute_id, value="")
 
     def is_not_empty(self) -> Condition:
-        """属性が空でないという条件"""
-        return NotEquals(self.attribute_id, "")
+        """属性値が空でないという条件"""
+        return NotEquals(self.attribute_id, value="")
 
 
 class Attribute(ABC):
@@ -115,7 +117,7 @@ class Attribute(ABC):
             raise ValueError(f"属性の種類が'{self.attribute['type']}'である属性は、クラス'{self.__class__.__name__}'では扱えません。")
 
     def disabled(self) -> Condition:
-        """属性値を入力できないようにします。"""
+        """属性値を入力できないという条件"""
         return CanInput(self.attribute_id, enable=False)
 
     @abstractmethod
@@ -145,9 +147,11 @@ class StringTextBox(Attribute, EmptyCheckMixin):
         return self.attribute["type"] in {"text", "comment"}
 
     def equals(self, value: str) -> Condition:
+        """引数`value`に渡された文字列に一致するという条件"""
         return Equals(self.attribute_id, value)
 
     def not_equals(self, value: str) -> Condition:
+        """引数`value`に渡された文字列に一致しないという条件"""
         return NotEquals(self.attribute_id, value)
 
     def matches(self, value: str) -> Condition:
@@ -181,6 +185,7 @@ class AnnotationLink(Attribute, EmptyCheckMixin):
         return self.attribute["type"] == "link"
 
     def has_label(self, label_ids: Optional[Collection[str]] = None, label_names: Optional[Collection[str]] = None) -> Condition:
+        """リンク先のアノテーションが、引数`label_ids`または`label_names`に一致するラベルであるという条件"""
         if label_ids is not None:
             labels = [self.accessor.get_label(label_id=label_id) for label_id in label_ids]
         elif label_names is not None:
@@ -198,9 +203,11 @@ class TrackingId(Attribute, EmptyCheckMixin):
         return self.attribute["type"] == "tracking"
 
     def equals(self, value: str) -> Condition:
+        """引数`value`に渡された文字列に一致するという条件"""
         return Equals(self.attribute_id, value)
 
     def not_equals(self, value: str) -> Condition:
+        """引数`value`に渡された文字列に一致しないという条件"""
         return NotEquals(self.attribute_id, value)
 
 
@@ -210,12 +217,14 @@ class Selection(Attribute, EmptyCheckMixin):
     def _is_valid_attribute_type(self) -> bool:
         return self.attribute["type"] in {"choice", "select"}
 
-    def is_selected(self, choice_id: str, choice_name: str) -> Condition:
+    def has_choice(self, *, choice_id: Optional[str] = None, choice_name: Optional[str] = None) -> Condition:
+        """引数`choice_id`または`choice_name`に一致する選択肢が選択されているという条件"""
         choices = self.attribute["choices"]
         choice = get_choice(choices, choice_id=choice_id, choice_name=choice_name)
         return Equals(self.attribute_id, choice["choice_id"])
 
-    def is_not_selected(self, choice_id: str, choice_name: str) -> Condition:
+    def not_has_choice(self, *, choice_id: Optional[str] = None, choice_name: Optional[str] = None) -> Condition:
+        """引数`choice_id`または`choice_name`に一致する選択肢が選択されていないという条件"""
         choices = self.attribute["choices"]
         choice = get_choice(choices, choice_id=choice_id, choice_name=choice_name)
         return NotEquals(self.attribute_id, choice["choice_id"])

--- a/annofabapi/util/attribute_restrictions.py
+++ b/annofabapi/util/attribute_restrictions.py
@@ -1,6 +1,7 @@
 """属性の制約を定義するモジュール。"""
 
-from abc import ABC, Collection, abstractmethod
+from abc import ABC, abstractmethod
+from collections.abc import Collection
 from typing import Any, Optional
 
 from annofabapi.util.annotation_specs import AnnotationSpecsAccessor, get_choice
@@ -111,7 +112,7 @@ class Attribute(ABC):
         self.attribute = self.accessor.get_attribute(attribute_id=attribute_id, attribute_name=attribute_name)
         self.attribute_id = self.attribute["additional_data_definition_id"]
         if self.is_valid_attribute_type() is False:
-            raise ValueError(f"属性の種類'{self.attribute['type']}'である属性は、クラス'{self.__class__.__name__}'では扱えません。")
+            raise ValueError(f"属性の種類が'{self.attribute['type']}'である属性は、クラス'{self.__class__.__name__}'では扱えません。")
 
     def disabled(self) -> Condition:
         """属性値を入力できないようにします。"""

--- a/annofabapi/util/attribute_restrictions.py
+++ b/annofabapi/util/attribute_restrictions.py
@@ -129,17 +129,31 @@ class StringTextBox(Attribute):
         """引数`value`に渡された正規表現に一致しないという条件"""
         return NotMatches(self.attribute_id, value)
 
+    def required(self) -> Condition:
+        """必須入力という条件"""
+        return NotEquals(self.attribute_id, "")
+
+class IntegerTextBox(Attribute):
+    """整数用のテキストボックスの属性"""
+
+    def equals(self, value: int) -> Condition:
+        """引数`value`に渡された整数に一致するという条件"""
+        return Equals(self.attribute_id, str(value))
+
+    def not_equals(self, value: int) -> Condition:
+        """引数`value`に渡された整数に一致しないという条件"""
+        return NotEquals(self.attribute_id, str(value))
+
+    def required(self) -> Condition:
+        """必須入力という条件"""
+        return NotEquals(self.attribute_id, "")
+
 
 class LinkAttribute:
     """アノテーションリンク属性"""
 
     pass
 
-
-class IntegerTextBoxAttribute:
-    """整数用のテキストボックスの属性"""
-
-    pass
 
 
 class SelectionAttribute:

--- a/annofabapi/util/attribute_restrictions.py
+++ b/annofabapi/util/attribute_restrictions.py
@@ -1,0 +1,155 @@
+"""属性の制約を定義するモジュール。"""
+
+from typing import Any
+from abc import ABC, abstractmethod
+
+
+class Condition(ABC):
+    def __init__(self, attr_id):
+        self._attr_id = attr_id
+
+    @property
+    def attr_id(self) -> str:
+        return self._attr_id
+
+    def generate(self) -> dict[str, Any]:
+        return {
+            "additional_data_definition_id": self.attr_id,
+            "condition": self.generate_condition()
+        }
+
+    @abstractmethod
+    def generate_condition(self) -> dict[str, Any]:
+        pass
+
+    def imply(self, condition: Condition) -> Condition2:
+        # implyを連続で使えない
+        return Imply(self, condition)
+
+
+class CanInput(Condition):
+    def __init__(self, attr_id: str, enable = False):
+        super().__init__(attr_id)
+        self.enable = enable
+
+    def generate_condition(self) -> dict[str, Any]:
+        return {
+            "_type": "CanInput",
+            "enable": self.enable
+        }
+
+class Equals(Condition):
+    def __init__(self, attr_id: str, value: str):
+        super().__init__(attr_id)
+        self.value = value
+
+    def generate_condition(self) -> dict[str, Any]:
+        return {
+            "_type": "Equals",
+            "value": self.value
+        }
+
+class NotEquals(Condition):
+    def __init__(self, attr_id: str, value: str):
+        super().__init__(attr_id)
+        self.value = value
+
+    def generate_condition(self) -> dict[str, Any]:
+        return {
+            "_type": "NotEquals",
+            "value": self.value
+        }
+
+class Matches(Condition):
+    def __init__(self, attr_id: str, re: str):
+        super().__init__(attr_id)
+        self.re = re
+
+    def generate_condition(self) -> dict[str, Any]:
+        return {
+            "_type": "Matches",
+            "value": self.re
+        }
+
+class NotMatches(Condition):
+    def __init__(self, attr_id: str, re: str):
+        super().__init__(attr_id)
+        self.re = re
+
+    def generate_condition(self) -> dict[str, Any]:
+        return {
+            "_type": "NotMatches",
+            "value": self.re
+        }
+
+class HasLabel(Condition):
+    def __init__(self, attr_id: str, label_ids: list[str]):
+        super().__init__(attr_id)
+        self.label_ids = label_ids
+
+    def generate_condition(self) -> dict[str, Any]:
+        return {
+            "_type": "HasLabel",
+            "value": self.label_ids
+        }
+
+class Imply(Condition):
+    def __init__(self, pre_condition: Condition, post_condition: Condition):
+        super().__init__(post_condition.attr_id)
+        self.pre_condition = pre_condition
+        self.post_condition = post_condition
+
+    def generate(self) -> dict[str, Any]:
+        return {
+            "additional_data_definition_id": self.attr_id,
+            "condition": self.generate_condition()
+        }
+
+    def generate_condition(self) -> dict[str, Any]:
+        return {
+            "_type": "Imply",
+            "premise": self.pre_condition.generate(),
+            "condition": self.post_condition.generate_condition()
+        }
+
+
+
+
+
+class Attribute(ABC):
+    def __init__(self, attribute_id: str):
+        self.attr_id = attribute_id
+        
+        
+class LinkAttribute:
+    """アノテーションリンク属性"""
+    pass
+
+
+class Checkbox(Attribute):
+    """チェックボックスの属性"""
+    def checked(self) -> Condition:
+        return Equals(self.attr_id, value)
+
+    def unchecked(self) -> Condition:
+        return Equals(self.attr_id, value)
+
+
+class StringTextBoxAttribute:
+    """文字列用のテキストボックス（自由記述）の属性"""
+    pass
+
+class IntegerTextBoxAttribute:
+    """整数用のテキストボックスの属性"""
+    pass
+
+
+class SelectionAttribute:
+    """排他選択の属性（ドロップダウンまたラジオボタン）"""
+    pass
+
+
+class TrackingIdAttribute:
+    """トラッキングID属性"""
+    pass
+

--- a/annofabapi/util/attribute_restrictions.py
+++ b/annofabapi/util/attribute_restrictions.py
@@ -1,4 +1,43 @@
-"""属性の制約を定義するモジュール。"""
+"""
+属性の制約に関するモジュール。
+
+以下のサンプルコードのように属性名で制約情報を出力できます。
+
+Examples:
+    # 「'occluded'チェックボックスがONならば、'note'テキストボックスは空ではない」という制約
+    >>> premise_restriction = Checkbox(accessor, attribute_name="occluded").checked()
+    >>> conclusion_restriction = StringTextBox(accessor, attribute_name="note").is_not_empty()
+    >>> restriction = premise_restriction.imply(conclusion_restriction)
+    >>> restriction.to_dict()
+    {
+        "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
+        "condition": {
+            "_type": "Imply",
+            "premise": {
+                "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
+                "condition": {"_type": "Equals", "value": "true"},
+            },
+            "condition": {"_type": "NotEquals", "value": ""},
+        },
+    }
+
+    # 「'occluded'チェックボックスがONならば、'car_kind'セレクトボックス(ラジオボタン)は選択肢'general_car'を選択しない」という制約
+    >>> premise_restriction = Checkbox(accessor, attribute_name="occluded").checked()
+    >>> conclusion_restriction = Selection(accessor, attribute_name="car_kind").not_has_choice(choice_name="general_car")
+    >>> restriction = premise_restriction.imply(conclusion_restriction)
+    >>> restriction.to_dict()
+    {
+        "additional_data_definition_id": "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
+        "condition": {
+            "_type": "Imply",
+            "premise": {
+                "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
+                "condition": {"_type": "Equals", "value": "true"},
+            },
+            "condition": {"_type": "Equals", "value": "7512ee39-8073-4e24-9b8c-93d99b76b7d2"},
+        },
+    }
+"""
 
 from abc import ABC, abstractmethod
 from collections.abc import Collection

--- a/docs/api_reference/index.rst
+++ b/docs/api_reference/index.rst
@@ -8,7 +8,6 @@ API reference
    api2
    wrapper
    resource
-   utils
    parser
    plugin
    dataclass
@@ -16,5 +15,8 @@ API reference
    segmentation
    pydantic_models
    models
+   util
+   utils
+   credentials
    
 

--- a/docs/api_reference/util.rst
+++ b/docs/api_reference/util.rst
@@ -1,0 +1,37 @@
+annofabapi.util package
+=======================
+
+Submodules
+----------
+
+annofabapi.util.annotation\_specs module
+----------------------------------------
+
+.. automodule:: annofabapi.util.annotation_specs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+annofabapi.util.attribute\_restrictions module
+----------------------------------------------
+
+.. automodule:: annofabapi.util.attribute_restrictions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+annofabapi.util.type\_util module
+---------------------------------
+
+.. automodule:: annofabapi.util.type_util
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: annofabapi.util
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ plugins = ["numpy.typing.mypy_plugin"]
 exclude = [
     'annofabapi/pydantic_models/.*\.py',
 ]
+show_column_numbers = true
 
 [tool.ruff]
 target-version = "py39"

--- a/tests/data/util/attribute_restrictions/annotation_specs.json
+++ b/tests/data/util/attribute_restrictions/annotation_specs.json
@@ -49,7 +49,8 @@
           "ec27de5d-122c-40e7-89bc-5500e37bae6a",
           "69a20a12-ef5f-446f-a03e-0c4ab487ff90",
           "2517f635-2269-4142-8ef4-16312b4cc9f7",
-          "9b05648d-1e16-4ea2-ab79-48907f5eed00"
+          "9b05648d-1e16-4ea2-ab79-48907f5eed00",
+          "e771ac4b-97d1-4af3-ba4b-f0e5b22e8648"
         ],
         "color" : {
           "red" : 251,
@@ -835,6 +836,36 @@
         "metadata" : {
           
         }
+      },
+      {
+        "additional_data_definition_id" : "e771ac4b-97d1-4af3-ba4b-f0e5b22e8648",
+        "read_only" : false,
+        "name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "truncated"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "truncated"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "truncated"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+        ],
+        "type" : "flag",
+        "default" : false,
+        "choices" : [
+        ],
+        "metadata" : {
+          
+        }
       }
     ],
     "restrictions" : [
@@ -853,14 +884,6 @@
           "value" : "",
           "_type" : "NotEquals"
         }
-      },
-      {
-        "additional_data_definition_id" : "ec27de5d-122c-40e7-89bc-5500e37bae6a",
-        "condition" : {
-          "labels" : [
-          ],
-          "_type" : "HasLabel"
-        }
       }
     ],
     "inspection_phrases" : [
@@ -869,7 +892,7 @@
     "auto_marking" : false,
     "annotation_type_version" : null,
     "format_version" : "3.0.0",
-    "last_updated_datetime" : "2025-03-20T13:53:31.006+09:00",
+    "last_updated_datetime" : "2025-03-20T14:45:23.641+09:00",
     "option" : {
       "can_overwrap" : true
     },

--- a/tests/data/util/attribute_restrictions/annotation_specs.json
+++ b/tests/data/util/attribute_restrictions/annotation_specs.json
@@ -1,0 +1,840 @@
+{
+    "labels" : [
+      {
+        "label_id" : "9d6cca8d-3f5a-4808-a6c9-0ae18a478176",
+        "label_name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "car"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "自動車"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "car"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "KeyQ",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "annotation_type" : "bounding_box",
+        "field_values" : {
+          "minimum_size_2d_with_default_insert_position" : {
+            "min_warn_rule" : {
+              "_type" : "And"
+            },
+            "min_width" : 35,
+            "min_height" : 35,
+            "position_for_minimum_bounding_box_insertion" : null,
+            "_type" : "MinimumSize2dWithDefaultInsertPosition"
+          },
+          "margin_of_error_tolerance" : {
+            "max_pixel" : 3,
+            "_type" : "MarginOfErrorTolerance"
+          }
+        },
+        "additional_data_definitions" : [
+          "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
+          "d349e76d-b59a-44cd-94b4-713a00b2e84d",
+          "ec27de5d-122c-40e7-89bc-5500e37bae6a",
+          "69a20a12-ef5f-446f-a03e-0c4ab487ff90",
+          "2517f635-2269-4142-8ef4-16312b4cc9f7"
+        ],
+        "color" : {
+          "red" : 251,
+          "green" : 0,
+          "blue" : 0
+        },
+        "metadata" : {
+          
+        }
+      },
+      {
+        "label_id" : "39d05700-7c12-4732-bc35-02d65367cc3e",
+        "label_name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "number_plate"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "ナンバープレート"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "number_plate"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "KeyW",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "annotation_type" : "bounding_box",
+        "field_values" : {
+          "minimum_size_2d_with_default_insert_position" : {
+            "min_warn_rule" : {
+              "_type" : "And"
+            },
+            "min_width" : 16,
+            "min_height" : 8,
+            "position_for_minimum_bounding_box_insertion" : null,
+            "_type" : "MinimumSize2dWithDefaultInsertPosition"
+          },
+          "margin_of_error_tolerance" : {
+            "max_pixel" : 3,
+            "_type" : "MarginOfErrorTolerance"
+          }
+        },
+        "additional_data_definitions" : [
+          "15ba8b9d-4882-40c2-bb31-ed3f68197c2e"
+        ],
+        "color" : {
+          "red" : 0,
+          "green" : 0,
+          "blue" : 251
+        },
+        "metadata" : {
+          
+        }
+      },
+      {
+        "label_id" : "afc8ffef-ce87-463d-bf62-070771465438",
+        "label_name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "white_line"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "白線"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "white_line"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "KeyE",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "annotation_type" : "polyline",
+        "field_values" : {
+          "display_line_direction" : {
+            "has_direction" : false,
+            "_type" : "DisplayLineDirection"
+          },
+          "minimum_size_2d" : {
+            "min_warn_rule" : {
+              "_type" : "And"
+            },
+            "min_width" : 6,
+            "min_height" : 6,
+            "_type" : "MinimumSize2d"
+          },
+          "margin_of_error_tolerance" : {
+            "max_pixel" : 3,
+            "_type" : "MarginOfErrorTolerance"
+          }
+        },
+        "additional_data_definitions" : [
+        ],
+        "color" : {
+          "red" : 225,
+          "green" : 255,
+          "blue" : 0
+        },
+        "metadata" : {
+          
+        }
+      },
+      {
+        "label_id" : "cf4d3a30-4efe-410d-b5e0-c35fd46d080c",
+        "label_name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "road"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "路面"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "road"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "KeyR",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "annotation_type" : "segmentation_v2",
+        "field_values" : {
+          "minimum_size_2d" : {
+            "min_warn_rule" : {
+              "_type" : "Or"
+            },
+            "min_width" : 6,
+            "min_height" : 6,
+            "_type" : "MinimumSize2d"
+          },
+          "margin_of_error_tolerance" : {
+            "max_pixel" : 3,
+            "_type" : "MarginOfErrorTolerance"
+          },
+          "annotation_editor_feature" : {
+            "append" : true,
+            "erase" : true,
+            "freehand" : true,
+            "rectangle_fill" : true,
+            "polygon_fill" : true,
+            "fill_near" : true,
+            "_type" : "AnnotationEditorFeature"
+          }
+        },
+        "additional_data_definitions" : [
+        ],
+        "color" : {
+          "red" : 253,
+          "green" : 88,
+          "blue" : 248
+        },
+        "metadata" : {
+          
+        }
+      },
+      {
+        "label_id" : "7391e5f4-38e9-4660-85b9-3d908506634c",
+        "label_name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "traffic_sign"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "交通標識"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "traffic_sign"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "KeyT",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "annotation_type" : "polygon",
+        "field_values" : {
+          "minimum_size_2d" : {
+            "min_warn_rule" : {
+              "_type" : "Or"
+            },
+            "min_width" : 6,
+            "min_height" : 6,
+            "_type" : "MinimumSize2d"
+          },
+          "margin_of_error_tolerance" : {
+            "max_pixel" : 3,
+            "_type" : "MarginOfErrorTolerance"
+          }
+        },
+        "additional_data_definitions" : [
+        ],
+        "color" : {
+          "red" : 0,
+          "green" : 255,
+          "blue" : 0
+        },
+        "metadata" : {
+          
+        }
+      },
+      {
+        "label_id" : "fcb847a5-5607-4467-a72b-fc11fb5cfbab",
+        "label_name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "whole"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "全体"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "whole"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "KeyY",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "annotation_type" : "classification",
+        "field_values" : {
+          
+        },
+        "additional_data_definitions" : [
+          "fff3fcc3-093d-41ce-90cf-b4d9b2688b78"
+        ],
+        "color" : {
+          "red" : 241,
+          "green" : 192,
+          "blue" : 243
+        },
+        "metadata" : {
+          
+        }
+      }
+    ],
+    "additionals" : [
+      {
+        "additional_data_definition_id" : "15ba8b9d-4882-40c2-bb31-ed3f68197c2e",
+        "read_only" : false,
+        "name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "link_car"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "リンク_車両"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "link_car"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "Digit4",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "type" : "link",
+        "default" : "",
+        "choices" : [
+        ],
+        "metadata" : {
+          
+        }
+      },
+      {
+        "additional_data_definition_id" : "d349e76d-b59a-44cd-94b4-713a00b2e84d",
+        "read_only" : false,
+        "name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "tracking"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "トラッキング"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "tracking"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "Digit1",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "type" : "tracking",
+        "default" : "",
+        "choices" : [
+        ],
+        "metadata" : {
+          
+        }
+      },
+      {
+        "additional_data_definition_id" : "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
+        "read_only" : false,
+        "name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "car_kind"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "種別"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "car_kind"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+        ],
+        "type" : "choice",
+        "default" : "7512ee39-8073-4e24-9b8c-93d99b76b7d2",
+        "choices" : [
+          {
+            "choice_id" : "7512ee39-8073-4e24-9b8c-93d99b76b7d2",
+            "name" : {
+              "messages" : [
+                {
+                  "lang" : "en-US",
+                  "message" : "general_car"
+                },
+                {
+                  "lang" : "ja-JP",
+                  "message" : "車両一般"
+                },
+                {
+                  "lang" : "vi-VN",
+                  "message" : "general_car"
+                }
+              ],
+              "default_lang" : "ja-JP"
+            },
+            "keybind" : [
+              {
+                "code" : "Digit1",
+                "shift" : true,
+                "ctrl" : false,
+                "alt" : false
+              }
+            ]
+          },
+          {
+            "choice_id" : "c07f9702-4760-4e7c-824d-b87bac356a80",
+            "name" : {
+              "messages" : [
+                {
+                  "lang" : "en-US",
+                  "message" : "emergency_vehicle"
+                },
+                {
+                  "lang" : "ja-JP",
+                  "message" : "緊急車両"
+                },
+                {
+                  "lang" : "vi-VN",
+                  "message" : "emergency_vehicle"
+                }
+              ],
+              "default_lang" : "ja-JP"
+            },
+            "keybind" : [
+              {
+                "code" : "Digit2",
+                "shift" : true,
+                "ctrl" : false,
+                "alt" : false
+              }
+            ]
+          },
+          {
+            "choice_id" : "75e848f81a-ce06-4669-bd07-4af96306de56",
+            "name" : {
+              "messages" : [
+                {
+                  "lang" : "en-US",
+                  "message" : "construction_vehicle"
+                },
+                {
+                  "lang" : "ja-JP",
+                  "message" : "重機"
+                },
+                {
+                  "lang" : "vi-VN",
+                  "message" : "construction_vehicle"
+                }
+              ],
+              "default_lang" : "ja-JP"
+            },
+            "keybind" : [
+              {
+                "code" : "Digit3",
+                "shift" : true,
+                "ctrl" : false,
+                "alt" : false
+              }
+            ]
+          }
+        ],
+        "metadata" : {
+          
+        }
+      },
+      {
+        "additional_data_definition_id" : "fff3fcc3-093d-41ce-90cf-b4d9b2688b78",
+        "read_only" : false,
+        "name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "weater"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "天候"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "weater"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+        ],
+        "type" : "choice",
+        "default" : "",
+        "choices" : [
+          {
+            "choice_id" : "c557a034-1abc-479a-bed3-3a33c006a195",
+            "name" : {
+              "messages" : [
+                {
+                  "lang" : "en-US",
+                  "message" : "fine"
+                },
+                {
+                  "lang" : "ja-JP",
+                  "message" : "晴れ"
+                },
+                {
+                  "lang" : "vi-VN",
+                  "message" : "fine"
+                }
+              ],
+              "default_lang" : "ja-JP"
+            },
+            "keybind" : [
+              {
+                "code" : "Digit5",
+                "shift" : false,
+                "ctrl" : false,
+                "alt" : false
+              }
+            ]
+          },
+          {
+            "choice_id" : "10744a0f-ceb0-4064-b2ce-f7d2d5714794",
+            "name" : {
+              "messages" : [
+                {
+                  "lang" : "en-US",
+                  "message" : "cloudy"
+                },
+                {
+                  "lang" : "ja-JP",
+                  "message" : "曇り"
+                },
+                {
+                  "lang" : "vi-VN",
+                  "message" : "cloudy"
+                }
+              ],
+              "default_lang" : "ja-JP"
+            },
+            "keybind" : [
+              {
+                "code" : "Digit6",
+                "shift" : false,
+                "ctrl" : false,
+                "alt" : false
+              }
+            ]
+          },
+          {
+            "choice_id" : "49515f1d-cc5c-41c1-8c5c-a13764ab30d2",
+            "name" : {
+              "messages" : [
+                {
+                  "lang" : "en-US",
+                  "message" : "rainy"
+                },
+                {
+                  "lang" : "ja-JP",
+                  "message" : "雨"
+                },
+                {
+                  "lang" : "vi-VN",
+                  "message" : "rainy"
+                }
+              ],
+              "default_lang" : "ja-JP"
+            },
+            "keybind" : [
+              {
+                "code" : "Digit7",
+                "shift" : false,
+                "ctrl" : false,
+                "alt" : false
+              }
+            ]
+          },
+          {
+            "choice_id" : "8f04498e-079f-409b-8e7c-703e006bdceb",
+            "name" : {
+              "messages" : [
+                {
+                  "lang" : "en-US",
+                  "message" : "other"
+                },
+                {
+                  "lang" : "ja-JP",
+                  "message" : "不明"
+                },
+                {
+                  "lang" : "vi-VN",
+                  "message" : "other"
+                }
+              ],
+              "default_lang" : "ja-JP"
+            },
+            "keybind" : [
+              {
+                "code" : "Digit8",
+                "shift" : false,
+                "ctrl" : false,
+                "alt" : false
+              }
+            ]
+          }
+        ],
+        "metadata" : {
+          
+        }
+      },
+      {
+        "additional_data_definition_id" : "ec27de5d-122c-40e7-89bc-5500e37bae6a",
+        "read_only" : false,
+        "name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "traffic_lane"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "車線"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "traffic_lane"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "Digit2",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "type" : "integer",
+        "default" : "",
+        "choices" : [
+        ],
+        "metadata" : {
+          
+        }
+      },
+      {
+        "additional_data_definition_id" : "69a20a12-ef5f-446f-a03e-0c4ab487ff90",
+        "read_only" : false,
+        "name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "condition"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "状態"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "condition"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+          {
+            "code" : "Digit3",
+            "shift" : false,
+            "ctrl" : false,
+            "alt" : false
+          }
+        ],
+        "type" : "select",
+        "default" : "",
+        "choices" : [
+          {
+            "choice_id" : "stopping",
+            "name" : {
+              "messages" : [
+                {
+                  "lang" : "en-US",
+                  "message" : "stopping"
+                },
+                {
+                  "lang" : "ja-JP",
+                  "message" : "停車"
+                },
+                {
+                  "lang" : "vi-VN",
+                  "message" : "stopping"
+                }
+              ],
+              "default_lang" : "ja-JP"
+            },
+            "keybind" : [
+            ]
+          },
+          {
+            "choice_id" : "running",
+            "name" : {
+              "messages" : [
+                {
+                  "lang" : "en-US",
+                  "message" : "running"
+                },
+                {
+                  "lang" : "ja-JP",
+                  "message" : "走行"
+                },
+                {
+                  "lang" : "vi-VN",
+                  "message" : "running"
+                }
+              ],
+              "default_lang" : "ja-JP"
+            },
+            "keybind" : [
+            ]
+          }
+        ],
+        "metadata" : {
+          
+        }
+      },
+      {
+        "additional_data_definition_id" : "2517f635-2269-4142-8ef4-16312b4cc9f7",
+        "read_only" : false,
+        "name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "occluded"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "occluded"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "occluded"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+        ],
+        "type" : "flag",
+        "default" : false,
+        "choices" : [
+        ],
+        "metadata" : {
+          
+        }
+      }
+    ],
+    "restrictions" : [
+      {
+        "additional_data_definition_id" : "15ba8b9d-4882-40c2-bb31-ed3f68197c2e",
+        "condition" : {
+          "labels" : [
+            "9d6cca8d-3f5a-4808-a6c9-0ae18a478176"
+          ],
+          "_type" : "HasLabel"
+        }
+      },
+      {
+        "additional_data_definition_id" : "d349e76d-b59a-44cd-94b4-713a00b2e84d",
+        "condition" : {
+          "value" : "",
+          "_type" : "NotEquals"
+        }
+      }
+    ],
+    "inspection_phrases" : [
+    ],
+    "comment" : null,
+    "auto_marking" : false,
+    "annotation_type_version" : null,
+    "format_version" : "3.0.0",
+    "last_updated_datetime" : "2025-03-20T13:47:34.17+09:00",
+    "option" : {
+      "can_overwrap" : true
+    },
+    "metadata" : {
+      
+    }
+  }

--- a/tests/data/util/attribute_restrictions/annotation_specs.json
+++ b/tests/data/util/attribute_restrictions/annotation_specs.json
@@ -853,6 +853,14 @@
           "value" : "",
           "_type" : "NotEquals"
         }
+      },
+      {
+        "additional_data_definition_id" : "ec27de5d-122c-40e7-89bc-5500e37bae6a",
+        "condition" : {
+          "labels" : [
+          ],
+          "_type" : "HasLabel"
+        }
       }
     ],
     "inspection_phrases" : [

--- a/tests/data/util/attribute_restrictions/annotation_specs.json
+++ b/tests/data/util/attribute_restrictions/annotation_specs.json
@@ -48,7 +48,8 @@
           "d349e76d-b59a-44cd-94b4-713a00b2e84d",
           "ec27de5d-122c-40e7-89bc-5500e37bae6a",
           "69a20a12-ef5f-446f-a03e-0c4ab487ff90",
-          "2517f635-2269-4142-8ef4-16312b4cc9f7"
+          "2517f635-2269-4142-8ef4-16312b4cc9f7",
+          "9b05648d-1e16-4ea2-ab79-48907f5eed00"
         ],
         "color" : {
           "red" : 251,
@@ -804,6 +805,36 @@
         "metadata" : {
           
         }
+      },
+      {
+        "additional_data_definition_id" : "9b05648d-1e16-4ea2-ab79-48907f5eed00",
+        "read_only" : false,
+        "name" : {
+          "messages" : [
+            {
+              "lang" : "en-US",
+              "message" : "note"
+            },
+            {
+              "lang" : "ja-JP",
+              "message" : "note"
+            },
+            {
+              "lang" : "vi-VN",
+              "message" : "note"
+            }
+          ],
+          "default_lang" : "ja-JP"
+        },
+        "keybind" : [
+        ],
+        "type" : "text",
+        "default" : "",
+        "choices" : [
+        ],
+        "metadata" : {
+          
+        }
       }
     ],
     "restrictions" : [
@@ -830,7 +861,7 @@
     "auto_marking" : false,
     "annotation_type_version" : null,
     "format_version" : "3.0.0",
-    "last_updated_datetime" : "2025-03-20T13:47:34.17+09:00",
+    "last_updated_datetime" : "2025-03-20T13:53:31.006+09:00",
     "option" : {
       "can_overwrap" : true
     },

--- a/tests/util/test_local_attribute_restrictions.py
+++ b/tests/util/test_local_attribute_restrictions.py
@@ -1,41 +1,46 @@
-import configparser
+import json
 from pathlib import Path
 
 import pytest
 
-from annofabapi.util.attribute_restrictions import Checkbox, StringTextBox, IntegerTextBox
+from annofabapi.util.annotation_specs import AnnotationSpecsAccessor
+from annofabapi.util.attribute_restrictions import Checkbox, IntegerTextBox, StringTextBox
+
+accessor = AnnotationSpecsAccessor(annotation_specs=json.loads(Path("tests/data/util/attribute_restrictions/annotation_specs.json").read_text()))
 
 
 class Test__Checkbox:
     def test__checked(self):
-        actual = Checkbox("id1").checked().generate()
-        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "Equals", "value": "true"}}
+        actual = Checkbox(accessor, attribute_id="2517f635-2269-4142-8ef4-16312b4cc9f7").checked().generate()
+        assert actual == {"additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7", "condition": {"_type": "Equals", "value": "true"}}
 
     def test__unchecked(self):
-        actual = Checkbox("id1").unchecked().generate()
-        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotEquals", "value": "true"}}
+        actual = Checkbox(accessor, attribute_name="occluded").unchecked().generate()
+        assert actual == {
+            "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
+            "condition": {"_type": "NotEquals", "value": "true"},
+        }
 
-    def test__unchecked(self):
-        actual = Checkbox("id1").unchecked().generate()
-        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotEquals", "value": "true"}}
+    def test__is_valid_attribute_type(self):
+        with pytest.raises(ValueError, match="属性の種類が'tracking'である属性は、クラス'Checkbox'では扱えません。"):
+            Checkbox(accessor, attribute_id="d349e76d-b59a-44cd-94b4-713a00b2e84d")
 
 
 class Test__StringTextBox:
     def test__matches(self):
-        actual = StringTextBox("id1").matches("\\w").generate()
+        actual = StringTextBox(accessor, attribute_id="id1").matches("\\w").generate()
         assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "Matches", "value": "\\w"}}
 
     def test__not_matches(self):
-        actual = StringTextBox("id1").not_matches("\\w").generate()
+        actual = StringTextBox(accessor, attribute_id="id1").not_matches("\\w").generate()
         assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotMatches", "value": "\\w"}}
 
 
 class Test__IntegerTextBox:
     def test__equals(self):
-        actual = IntegerTextBox("id1").equals(10).generate()
+        actual = IntegerTextBox(accessor, attribute_id="id1").equals(10).generate()
         assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "Equals", "value": "10"}}
 
     def test__not_matches(self):
-        actual = IntegerTextBox("id1").not_equals(10).generate()
+        actual = IntegerTextBox(accessor, attribute_id="id1").not_equals(10).generate()
         assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotEquals", "value": "10"}}
-

--- a/tests/util/test_local_attribute_restrictions.py
+++ b/tests/util/test_local_attribute_restrictions.py
@@ -110,3 +110,54 @@ class Test__Selection:
             "additional_data_definition_id": "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
             "condition": {"_type": "NotEquals", "value": "7512ee39-8073-4e24-9b8c-93d99b76b7d2"},
         }
+
+
+class Test__imply:
+    def test__occludedチェックボックスがONならばnoteテキストボックスは空ではない(self):
+        condition = Checkbox(accessor, attribute_name="occluded").checked().imply(StringTextBox(accessor, attribute_name="note").is_not_empty())
+        actual = condition.generate()
+        assert actual == {
+            "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
+            "condition": {
+                "_type": "Imply",
+                "premise": {
+                    "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
+                    "condition": {"_type": "Equals", "value": "true"},
+                },
+                "condition": {"_type": "NotEquals", "value": ""},
+            },
+        }
+
+    def test__occludedチェックボックスがONかつtraffic_laneが2ならばnoteテキストボックスは空ではない(self):
+        condition = (
+            Checkbox(accessor, attribute_name="occluded")
+            .checked()
+            .imply(
+                IntegerTextBox(accessor, attribute_name="traffic_lane").equals(2).imply(StringTextBox(accessor, attribute_name="note").is_not_empty())
+            )
+        )
+        actual = condition.generate()
+        assert actual == {
+            "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
+            "condition": {
+                "_type": "Imply",
+                "premise": {
+                    "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
+                    "condition": {"_type": "Equals", "value": "true"},
+                },
+                "condition": {
+                    "_type": "Imply",
+                    "premise": {
+                        "additional_data_definition_id": "ec27de5d-122c-40e7-89bc-5500e37bae6a",
+                        "condition": {"_type": "Equals", "value": "2"},
+                    },
+                    "condition": {"_type": "NotEquals", "value": ""},
+                },
+            },
+        }
+
+    def test__implyメソッドの戻りに対してimplyメソッドを実行するとNotImplementedErrorが発生する(self):
+        with pytest.raises(NotImplementedError):
+            Checkbox(accessor, attribute_name="occluded").checked().imply(IntegerTextBox(accessor, attribute_name="traffic_lane").equals(2)).imply(
+                StringTextBox(accessor, attribute_name="note").is_not_empty()
+            )

--- a/tests/util/test_local_attribute_restrictions.py
+++ b/tests/util/test_local_attribute_restrictions.py
@@ -63,7 +63,7 @@ class Test__IntegerTextBox:
         actual = IntegerTextBox(accessor, attribute_name="traffic_lane").equals(10).to_dict()
         assert actual == {"additional_data_definition_id": "ec27de5d-122c-40e7-89bc-5500e37bae6a", "condition": {"_type": "Equals", "value": "10"}}
 
-    def test__not_matches(self):
+    def test__not_equals(self):
         actual = IntegerTextBox(accessor, attribute_name="traffic_lane").not_equals(10).to_dict()
         assert actual == {"additional_data_definition_id": "ec27de5d-122c-40e7-89bc-5500e37bae6a", "condition": {"_type": "NotEquals", "value": "10"}}
 

--- a/tests/util/test_local_attribute_restrictions.py
+++ b/tests/util/test_local_attribute_restrictions.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from annofabapi.util.attribute_restrictions import Checkbox, StringTextBox
+from annofabapi.util.attribute_restrictions import Checkbox, StringTextBox, IntegerTextBox
 
 
 class Test__Checkbox:
@@ -28,3 +28,14 @@ class Test__StringTextBox:
     def test__not_matches(self):
         actual = StringTextBox("id1").not_matches("\\w").generate()
         assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotMatches", "value": "\\w"}}
+
+
+class Test__IntegerTextBox:
+    def test__equals(self):
+        actual = IntegerTextBox("id1").equals(10).generate()
+        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "Equals", "value": "10"}}
+
+    def test__not_matches(self):
+        actual = IntegerTextBox("id1").not_equals(10).generate()
+        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotEquals", "value": "10"}}
+

--- a/tests/util/test_local_attribute_restrictions.py
+++ b/tests/util/test_local_attribute_restrictions.py
@@ -28,19 +28,41 @@ class Test__Checkbox:
 
 class Test__StringTextBox:
     def test__matches(self):
-        actual = StringTextBox(accessor, attribute_id="id1").matches("\\w").generate()
-        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "Matches", "value": "\\w"}}
+        actual = StringTextBox(accessor, attribute_name="note").matches("\\w").generate()
+        assert actual == {"additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00", "condition": {"_type": "Matches", "value": "\\w"}}
 
     def test__not_matches(self):
-        actual = StringTextBox(accessor, attribute_id="id1").not_matches("\\w").generate()
-        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotMatches", "value": "\\w"}}
+        actual = StringTextBox(accessor, attribute_name="note").not_matches("\\w").generate()
+        assert actual == {
+            "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
+            "condition": {"_type": "NotMatches", "value": "\\w"},
+        }
+
+    def test__equals(self):
+        actual = StringTextBox(accessor, attribute_name="note").equals("foo").generate()
+        assert actual == {"additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00", "condition": {"_type": "Equals", "value": "foo"}}
+
+    def test__not_equals(self):
+        actual = StringTextBox(accessor, attribute_name="note").not_equals("foo").generate()
+        assert actual == {
+            "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
+            "condition": {"_type": "NotEquals", "value": "foo"},
+        }
+
+    def test__is_empty(self):
+        actual = StringTextBox(accessor, attribute_name="note").is_empty().generate()
+        assert actual == {"additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00", "condition": {"_type": "Equals", "value": ""}}
+
+    def test__is_not_empty(self):
+        actual = StringTextBox(accessor, attribute_name="note").is_not_empty().generate()
+        assert actual == {"additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00", "condition": {"_type": "NotEquals", "value": ""}}
 
 
 class Test__IntegerTextBox:
     def test__equals(self):
-        actual = IntegerTextBox(accessor, attribute_id="id1").equals(10).generate()
-        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "Equals", "value": "10"}}
+        actual = IntegerTextBox(accessor, attribute_name="traffic_lane").equals(10).generate()
+        assert actual == {"additional_data_definition_id": "ec27de5d-122c-40e7-89bc-5500e37bae6a", "condition": {"_type": "Equals", "value": "10"}}
 
     def test__not_matches(self):
-        actual = IntegerTextBox(accessor, attribute_id="id1").not_equals(10).generate()
-        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotEquals", "value": "10"}}
+        actual = IntegerTextBox(accessor, attribute_name="traffic_lane").not_equals(10).generate()
+        assert actual == {"additional_data_definition_id": "ec27de5d-122c-40e7-89bc-5500e37bae6a", "condition": {"_type": "NotEquals", "value": "10"}}

--- a/tests/util/test_local_attribute_restrictions.py
+++ b/tests/util/test_local_attribute_restrictions.py
@@ -1,0 +1,30 @@
+import configparser
+from pathlib import Path
+
+import pytest
+
+from annofabapi.util.attribute_restrictions import Checkbox, StringTextBox
+
+
+class Test__Checkbox:
+    def test__checked(self):
+        actual = Checkbox("id1").checked().generate()
+        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "Equals", "value": "true"}}
+
+    def test__unchecked(self):
+        actual = Checkbox("id1").unchecked().generate()
+        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotEquals", "value": "true"}}
+
+    def test__unchecked(self):
+        actual = Checkbox("id1").unchecked().generate()
+        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotEquals", "value": "true"}}
+
+
+class Test__StringTextBox:
+    def test__matches(self):
+        actual = StringTextBox("id1").matches("\\w").generate()
+        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "Matches", "value": "\\w"}}
+
+    def test__not_matches(self):
+        actual = StringTextBox("id1").not_matches("\\w").generate()
+        assert actual == {"additional_data_definition_id": "id1", "condition": {"_type": "NotMatches", "value": "\\w"}}

--- a/tests/util/test_local_attribute_restrictions.py
+++ b/tests/util/test_local_attribute_restrictions.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from annofabapi.util.annotation_specs import AnnotationSpecsAccessor
-from annofabapi.util.attribute_restrictions import Checkbox, IntegerTextBox, StringTextBox
+from annofabapi.util.attribute_restrictions import AnnotationLink, Checkbox, IntegerTextBox, Selection, StringTextBox, TrackingId
 
 accessor = AnnotationSpecsAccessor(annotation_specs=json.loads(Path("tests/data/util/attribute_restrictions/annotation_specs.json").read_text()))
 
@@ -66,3 +66,47 @@ class Test__IntegerTextBox:
     def test__not_matches(self):
         actual = IntegerTextBox(accessor, attribute_name="traffic_lane").not_equals(10).generate()
         assert actual == {"additional_data_definition_id": "ec27de5d-122c-40e7-89bc-5500e37bae6a", "condition": {"_type": "NotEquals", "value": "10"}}
+
+
+class Test__AnnotationLink:
+    def test__has_label(self):
+        actual = AnnotationLink(accessor, attribute_name="link_car").has_label(label_names=["car"]).generate()
+        assert actual == {
+            "additional_data_definition_id": "15ba8b9d-4882-40c2-bb31-ed3f68197c2e",
+            "condition": {"_type": "HasLabel", "labels": ["9d6cca8d-3f5a-4808-a6c9-0ae18a478176"]},
+        }
+
+        actual = AnnotationLink(accessor, attribute_name="link_car").has_label(label_ids=["9d6cca8d-3f5a-4808-a6c9-0ae18a478176"]).generate()
+        assert actual == {
+            "additional_data_definition_id": "15ba8b9d-4882-40c2-bb31-ed3f68197c2e",
+            "condition": {"_type": "HasLabel", "labels": ["9d6cca8d-3f5a-4808-a6c9-0ae18a478176"]},
+        }
+
+
+class Test__TrackingId:
+    def test__equals(self):
+        actual = TrackingId(accessor, attribute_name="tracking").equals("foo").generate()
+        assert actual == {"additional_data_definition_id": "d349e76d-b59a-44cd-94b4-713a00b2e84d", "condition": {"_type": "Equals", "value": "foo"}}
+
+    def test__not_equals(self):
+        actual = TrackingId(accessor, attribute_name="tracking").not_equals("foo").generate()
+        assert actual == {
+            "additional_data_definition_id": "d349e76d-b59a-44cd-94b4-713a00b2e84d",
+            "condition": {"_type": "NotEquals", "value": "foo"},
+        }
+
+
+class Test__Selection:
+    def test__has_choice(self):
+        actual = Selection(accessor, attribute_name="car_kind").has_choice(choice_name="general_car").generate()
+        assert actual == {
+            "additional_data_definition_id": "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
+            "condition": {"_type": "Equals", "value": "7512ee39-8073-4e24-9b8c-93d99b76b7d2"},
+        }
+
+    def test__not_has_choice(self):
+        actual = Selection(accessor, attribute_name="car_kind").not_has_choice(choice_id="7512ee39-8073-4e24-9b8c-93d99b76b7d2").generate()
+        assert actual == {
+            "additional_data_definition_id": "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
+            "condition": {"_type": "NotEquals", "value": "7512ee39-8073-4e24-9b8c-93d99b76b7d2"},
+        }

--- a/tests/util/test_local_attribute_restrictions.py
+++ b/tests/util/test_local_attribute_restrictions.py
@@ -11,11 +11,11 @@ accessor = AnnotationSpecsAccessor(annotation_specs=json.loads(Path("tests/data/
 
 class Test__Checkbox:
     def test__checked(self):
-        actual = Checkbox(accessor, attribute_id="2517f635-2269-4142-8ef4-16312b4cc9f7").checked().generate()
+        actual = Checkbox(accessor, attribute_id="2517f635-2269-4142-8ef4-16312b4cc9f7").checked().to_dict()
         assert actual == {"additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7", "condition": {"_type": "Equals", "value": "true"}}
 
     def test__unchecked(self):
-        actual = Checkbox(accessor, attribute_name="occluded").unchecked().generate()
+        actual = Checkbox(accessor, attribute_name="occluded").unchecked().to_dict()
         assert actual == {
             "additional_data_definition_id": "2517f635-2269-4142-8ef4-16312b4cc9f7",
             "condition": {"_type": "NotEquals", "value": "true"},
@@ -28,55 +28,55 @@ class Test__Checkbox:
 
 class Test__StringTextBox:
     def test__matches(self):
-        actual = StringTextBox(accessor, attribute_name="note").matches("\\w").generate()
+        actual = StringTextBox(accessor, attribute_name="note").matches("\\w").to_dict()
         assert actual == {"additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00", "condition": {"_type": "Matches", "value": "\\w"}}
 
     def test__not_matches(self):
-        actual = StringTextBox(accessor, attribute_name="note").not_matches("\\w").generate()
+        actual = StringTextBox(accessor, attribute_name="note").not_matches("\\w").to_dict()
         assert actual == {
             "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
             "condition": {"_type": "NotMatches", "value": "\\w"},
         }
 
     def test__equals(self):
-        actual = StringTextBox(accessor, attribute_name="note").equals("foo").generate()
+        actual = StringTextBox(accessor, attribute_name="note").equals("foo").to_dict()
         assert actual == {"additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00", "condition": {"_type": "Equals", "value": "foo"}}
 
     def test__not_equals(self):
-        actual = StringTextBox(accessor, attribute_name="note").not_equals("foo").generate()
+        actual = StringTextBox(accessor, attribute_name="note").not_equals("foo").to_dict()
         assert actual == {
             "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
             "condition": {"_type": "NotEquals", "value": "foo"},
         }
 
     def test__is_empty(self):
-        actual = StringTextBox(accessor, attribute_name="note").is_empty().generate()
+        actual = StringTextBox(accessor, attribute_name="note").is_empty().to_dict()
         assert actual == {"additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00", "condition": {"_type": "Equals", "value": ""}}
 
     def test__is_not_empty(self):
-        actual = StringTextBox(accessor, attribute_name="note").is_not_empty().generate()
+        actual = StringTextBox(accessor, attribute_name="note").is_not_empty().to_dict()
         assert actual == {"additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00", "condition": {"_type": "NotEquals", "value": ""}}
 
 
 class Test__IntegerTextBox:
     def test__equals(self):
-        actual = IntegerTextBox(accessor, attribute_name="traffic_lane").equals(10).generate()
+        actual = IntegerTextBox(accessor, attribute_name="traffic_lane").equals(10).to_dict()
         assert actual == {"additional_data_definition_id": "ec27de5d-122c-40e7-89bc-5500e37bae6a", "condition": {"_type": "Equals", "value": "10"}}
 
     def test__not_matches(self):
-        actual = IntegerTextBox(accessor, attribute_name="traffic_lane").not_equals(10).generate()
+        actual = IntegerTextBox(accessor, attribute_name="traffic_lane").not_equals(10).to_dict()
         assert actual == {"additional_data_definition_id": "ec27de5d-122c-40e7-89bc-5500e37bae6a", "condition": {"_type": "NotEquals", "value": "10"}}
 
 
 class Test__AnnotationLink:
     def test__has_label(self):
-        actual = AnnotationLink(accessor, attribute_name="link_car").has_label(label_names=["car"]).generate()
+        actual = AnnotationLink(accessor, attribute_name="link_car").has_label(label_names=["car"]).to_dict()
         assert actual == {
             "additional_data_definition_id": "15ba8b9d-4882-40c2-bb31-ed3f68197c2e",
             "condition": {"_type": "HasLabel", "labels": ["9d6cca8d-3f5a-4808-a6c9-0ae18a478176"]},
         }
 
-        actual = AnnotationLink(accessor, attribute_name="link_car").has_label(label_ids=["9d6cca8d-3f5a-4808-a6c9-0ae18a478176"]).generate()
+        actual = AnnotationLink(accessor, attribute_name="link_car").has_label(label_ids=["9d6cca8d-3f5a-4808-a6c9-0ae18a478176"]).to_dict()
         assert actual == {
             "additional_data_definition_id": "15ba8b9d-4882-40c2-bb31-ed3f68197c2e",
             "condition": {"_type": "HasLabel", "labels": ["9d6cca8d-3f5a-4808-a6c9-0ae18a478176"]},
@@ -85,11 +85,11 @@ class Test__AnnotationLink:
 
 class Test__TrackingId:
     def test__equals(self):
-        actual = TrackingId(accessor, attribute_name="tracking").equals("foo").generate()
+        actual = TrackingId(accessor, attribute_name="tracking").equals("foo").to_dict()
         assert actual == {"additional_data_definition_id": "d349e76d-b59a-44cd-94b4-713a00b2e84d", "condition": {"_type": "Equals", "value": "foo"}}
 
     def test__not_equals(self):
-        actual = TrackingId(accessor, attribute_name="tracking").not_equals("foo").generate()
+        actual = TrackingId(accessor, attribute_name="tracking").not_equals("foo").to_dict()
         assert actual == {
             "additional_data_definition_id": "d349e76d-b59a-44cd-94b4-713a00b2e84d",
             "condition": {"_type": "NotEquals", "value": "foo"},
@@ -98,14 +98,14 @@ class Test__TrackingId:
 
 class Test__Selection:
     def test__has_choice(self):
-        actual = Selection(accessor, attribute_name="car_kind").has_choice(choice_name="general_car").generate()
+        actual = Selection(accessor, attribute_name="car_kind").has_choice(choice_name="general_car").to_dict()
         assert actual == {
             "additional_data_definition_id": "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
             "condition": {"_type": "Equals", "value": "7512ee39-8073-4e24-9b8c-93d99b76b7d2"},
         }
 
     def test__not_has_choice(self):
-        actual = Selection(accessor, attribute_name="car_kind").not_has_choice(choice_id="7512ee39-8073-4e24-9b8c-93d99b76b7d2").generate()
+        actual = Selection(accessor, attribute_name="car_kind").not_has_choice(choice_id="7512ee39-8073-4e24-9b8c-93d99b76b7d2").to_dict()
         assert actual == {
             "additional_data_definition_id": "cbb0155f-1631-48e1-8fc3-43c5f254b6f2",
             "condition": {"_type": "NotEquals", "value": "7512ee39-8073-4e24-9b8c-93d99b76b7d2"},
@@ -115,7 +115,7 @@ class Test__Selection:
 class Test__imply:
     def test__occludedチェックボックスがONならばnoteテキストボックスは空ではない(self):
         condition = Checkbox(accessor, attribute_name="occluded").checked().imply(StringTextBox(accessor, attribute_name="note").is_not_empty())
-        actual = condition.generate()
+        actual = condition.to_dict()
         assert actual == {
             "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
             "condition": {
@@ -136,7 +136,7 @@ class Test__imply:
                 IntegerTextBox(accessor, attribute_name="traffic_lane").equals(2).imply(StringTextBox(accessor, attribute_name="note").is_not_empty())
             )
         )
-        actual = condition.generate()
+        actual = condition.to_dict()
         assert actual == {
             "additional_data_definition_id": "9b05648d-1e16-4ea2-ab79-48907f5eed00",
             "condition": {


### PR DESCRIPTION
属性間の制約を設定するには、ユーザー自身でJSONを作成する必要があります。

自分でJSONを書く場合、以下の問題があります。

* 属性名でなく属性IDで表現するため（ラベルや選択肢も同様）、JSONだけではどのような制約なのかが分からない
* 利用できない制約（たとえばトラッキングID属性に対して「正規表現に一致する」など）を表現できてしまう。
* 「AかつBならばC」という制約を、「A -> (B -> C)」でなく「(A -> B) -> C」という表現にしてしまい、期待通りの制約が設定できない

上記の問題を解決するため、属性の制約を定義できるモジュールを作成しました。
このモジュールの特徴は以下の通りです。

* IDだけでなく英語名で表現できる
* 利用できない制約に対応するメソッドは定義されていない
* 属性のUIに対応したメソッドが定義されている。たとえば「チェックボックスがON」という制約は、`checked()`というメソッドで表現できる



* 

