### PR TITLE
`annofab.util.annotation_specs.AnnotationSpecsAccessor`の`get_attribute`関数に`label`引数を追加して、指定したラベルに含まれる属性情報を取得できるようにしました。

### DIFF
--- a/tests/util/test_annotation_specs.py
+++ b/tests/util/test_annotation_specs.py
@@ -35,8 +35,8 @@ class Test__AnnotationSpecsAccessor:
     def setup_method(self):
         self.annotation_specs = {
             "labels": [
-                {"label_id": "1", "label_name": {"messages": [{"lang": "en-US", "message": "Car"}]}},
-                {"label_id": "2", "label_name": {"messages": [{"lang": "en-US", "message": "Bike"}]}},
+                {"label_id": "1", "label_name": {"messages": [{"lang": "en-US", "message": "Car"}]}, "additional_data_definitions": ["1", "2"]},
+                {"label_id": "2", "label_name": {"messages": [{"lang": "en-US", "message": "Bike"}]}, "additional_data_definitions": []},
             ],
             "additionals": [
                 {"additional_data_definition_id": "1", "name": {"messages": [{"lang": "en-US", "message": "Color"}]}},
@@ -72,6 +72,17 @@ class Test__AnnotationSpecsAccessor:
     def test_get_attribute_not_found(self):
         with pytest.raises(ValueError):
             self.accessor.get_attribute(attribute_id="3")
+
+    def test_get_attribute_by_id_and_label(self):
+        label = self.accessor.get_label(label_id="1")
+        attribute = self.accessor.get_attribute(attribute_id="1", label=label)
+        assert attribute["additional_data_definition_id"] == "1"
+        assert get_english_message(attribute["name"]) == "Color"
+
+    def test_get_attribute_by_id_and_label__not_found(self):
+        label = self.accessor.get_label(label_id="2")
+        with pytest.raises(ValueError):
+            self.accessor.get_attribute(attribute_id="1", label=label)
 
 
 class Test__get_choice:


### PR DESCRIPTION
# 背景
ラベル`car`とラベル`bike`には、それぞれ`type`という属性が存在するが、属性の定義自体が異なるケースはあります。
このように属性名が重複しているケースは多々あります。
その場合でも、属性情報を取得できるようにするため、「指定したラベルが参照している属性」という条件で絞り込めるようにしました。
