### PR TITLE
`AnnotationSpecsAccessor`に定型指摘に関するメソッドを追加しました

### DIFF
--- a/annofabapi/util/annotation_specs.py
+++ b/annofabapi/util/annotation_specs.py
@@ -36,6 +36,13 @@ class AttributeDefinition(TypedDict):
     choices: list[AttributeChoice] | None
 
 
+class InspectionPhrase(TypedDict):
+    """定型指摘です。"""
+
+    id: str
+    text: InternationalizationMessage
+
+
 class LabelDefinition(TypedDict):
     """アノテーション仕様上のラベル定義です。"""
 
@@ -261,6 +268,30 @@ def get_label(labels: list[LabelDefinition], *, label_id: str | None = None, lab
     return result[0]
 
 
+def get_inspection_phrase(
+    inspection_phrases: list[InspectionPhrase],
+    *,
+    inspection_phrase_id: str,
+) -> InspectionPhrase:
+    """
+    定型指摘を取得します。
+
+    Args:
+        inspection_phrases: 定型指摘のリスト
+        inspection_phrase_id: 定型指摘ID
+
+    Raises:
+        ValueError: 引数に合致する定型指摘が見つからない。または複数見つかった。
+    """
+    result = [e for e in inspection_phrases if e["id"] == inspection_phrase_id]
+
+    if len(result) == 0:
+        raise ValueError(f"定型指摘が見つかりませんでした。 :: inspection_phrase_id='{inspection_phrase_id}'")
+    if len(result) > 1:
+        raise ValueError(f"定型指摘が複数（{len(result)}件）見つかりました。 :: inspection_phrase_id='{inspection_phrase_id}'")
+    return result[0]
+
+
 class AnnotationSpecsAccessor:
     """
     アノテーション仕様の情報にアクセスするためのクラス。
@@ -273,6 +304,7 @@ class AnnotationSpecsAccessor:
         self.annotation_specs = annotation_specs
         self.labels: list[LabelDefinition] = annotation_specs["labels"]
         self.additionals: list[AttributeDefinition] = annotation_specs["additionals"]
+        self.inspection_phrases: list[InspectionPhrase] = annotation_specs["inspection_phrases"]
 
     def get_attribute(
         self, *, attribute_id: str | None = None, attribute_name: str | None = None, label: LabelDefinition | None = None
@@ -304,3 +336,22 @@ class AnnotationSpecsAccessor:
 
         """
         return get_label(self.labels, label_id=label_id, label_name=label_name)
+
+    def get_inspection_phrase(
+        self,
+        *,
+        inspection_phrase_id: str,
+    ) -> InspectionPhrase:
+        """
+        定型指摘を取得します。
+
+        Args:
+            inspection_phrase_id: 定型指摘ID
+
+        Raises:
+            ValueError: 引数に合致する定型指摘が見つからない。または複数見つかった。
+        """
+        return get_inspection_phrase(
+            self.inspection_phrases,
+            inspection_phrase_id=inspection_phrase_id,
+        )

--- a/tests/util/test_annotation_specs.py
+++ b/tests/util/test_annotation_specs.py
@@ -3,6 +3,7 @@ import pytest
 from annofabapi.util.annotation_specs import (
     AnnotationSpecsAccessor,
     AttributeChoice,
+    InspectionPhrase,
     LabelNameHolder,
     Lang,
     NameHolder,
@@ -10,6 +11,7 @@ from annofabapi.util.annotation_specs import (
     get_choice,
     get_choice_name_en,
     get_english_message,
+    get_inspection_phrase,
     get_label_name_en,
     get_message_with_lang,
 )
@@ -105,6 +107,26 @@ class Test__AnnotationSpecsAccessor:
                 {"additional_data_definition_id": "1", "name": {"messages": [{"lang": "en-US", "message": "Color"}]}},
                 {"additional_data_definition_id": "2", "name": {"messages": [{"lang": "en-US", "message": "Size"}]}},
             ],
+            "inspection_phrases": [
+                {
+                    "id": "inspection_phrase_id_1",
+                    "text": {
+                        "messages": [
+                            {"lang": "ja-JP", "message": "画像がぼやけています。"},
+                            {"lang": "en-US", "message": "The image is blurry."},
+                        ]
+                    },
+                },
+                {
+                    "id": "inspection_phrase_id_2",
+                    "text": {
+                        "messages": [
+                            {"lang": "ja-JP", "message": "対象物が隠れています。"},
+                            {"lang": "en-US", "message": "The object is occluded."},
+                        ]
+                    },
+                },
+            ],
         }
         self.accessor = AnnotationSpecsAccessor(self.annotation_specs)
 
@@ -146,6 +168,31 @@ class Test__AnnotationSpecsAccessor:
         label = self.accessor.get_label(label_id="2")
         with pytest.raises(ValueError):
             self.accessor.get_attribute(attribute_id="1", label=label)
+
+    def test_get_inspection_phrase_by_id(self):
+        inspection_phrase = self.accessor.get_inspection_phrase(inspection_phrase_id="inspection_phrase_id_1")
+        assert inspection_phrase["id"] == "inspection_phrase_id_1"
+        assert get_message_with_lang(inspection_phrase["text"], Lang.EN_US) == "The image is blurry."
+
+    def test_get_inspection_phrase_not_found(self):
+        with pytest.raises(ValueError):
+            self.accessor.get_inspection_phrase(inspection_phrase_id="inspection_phrase_id_3")
+
+
+class Test__get_inspection_phrase:
+    def setup_method(self):
+        self.inspection_phrases: list[InspectionPhrase] = [
+            {"id": "1", "text": {"messages": [{"lang": "en-US", "message": "Blurry image"}]}},
+            {"id": "2", "text": {"messages": [{"lang": "en-US", "message": "Occluded object"}]}},
+        ]
+
+    def test_get_inspection_phrase_by_id(self):
+        inspection_phrase = get_inspection_phrase(self.inspection_phrases, inspection_phrase_id="1")
+        assert inspection_phrase["id"] == "1"
+
+    def test_get_inspection_phrase_not_found(self):
+        with pytest.raises(ValueError):
+            get_inspection_phrase(self.inspection_phrases, inspection_phrase_id="3")
 
 
 class Test__get_choice:


### PR DESCRIPTION
## Summary
- Add InspectionPhrase TypedDict and keep inspection_phrases on AnnotationSpecsAccessor
- Add ID-based get_inspection_phrase helpers
- Add tests for ID lookup and not-found behavior

## Tests
- make format
- make lint
- uv run pytest tests/util/test_annotation_specs.py